### PR TITLE
Improve home gallery browsing and add project detail page

### DIFF
--- a/app/components/ProjectCard.tsx
+++ b/app/components/ProjectCard.tsx
@@ -4,9 +4,58 @@ import type { DemoProjectWithAuthor } from "~/data/fakeData";
 
 type ProjectCardProps = {
   project: DemoProjectWithAuthor;
+  viewMode?: "gallery" | "list";
 };
 
-export function ProjectCard({ project }: ProjectCardProps) {
+export function ProjectCard({
+  project,
+  viewMode = "gallery",
+}: ProjectCardProps) {
+  if (viewMode === "list") {
+    return (
+      <article className="rounded-3xl border border-stone-200 bg-white px-6 py-5 shadow-sm">
+        <div className="grid gap-4 md:grid-cols-[minmax(0,2fr)_minmax(0,1.2fr)_140px_120px] md:items-center">
+          <div className="space-y-1">
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-stone-400 md:hidden">
+              Title
+            </p>
+            <h2 className="text-xl font-semibold tracking-tight text-stone-950">
+              <Link className="hover:underline" to={`/projects/${project.id}`}>
+                {project.title}
+              </Link>
+            </h2>
+          </div>
+
+          <div className="space-y-1">
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-stone-400 md:hidden">
+              Author
+            </p>
+            <Link
+              className="text-stone-700 hover:text-stone-950 hover:underline"
+              to={`/authors/${project.author.id}`}
+            >
+              {project.author.name}
+            </Link>
+          </div>
+
+          <div className="space-y-1 text-stone-600">
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-stone-400 md:hidden">
+              Date
+            </p>
+            <span>{project.createdAt}</span>
+          </div>
+
+          <div className="space-y-1 text-stone-600">
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-stone-400 md:hidden">
+              Likes
+            </p>
+            <span>{project.likes}</span>
+          </div>
+        </div>
+      </article>
+    );
+  }
+
   return (
     <article className="rounded-3xl border border-stone-200 bg-white p-6 shadow-sm">
       <div className="flex items-start justify-between gap-4">

--- a/app/components/ProjectList.tsx
+++ b/app/components/ProjectList.tsx
@@ -1,0 +1,29 @@
+import { ProjectCard } from "~/components/ProjectCard";
+import type { DemoProjectWithAuthor } from "~/data/fakeData";
+
+type ProjectListProps = {
+  projects: DemoProjectWithAuthor[];
+  viewMode: "gallery" | "list";
+};
+
+export function ProjectList({ projects, viewMode }: ProjectListProps) {
+  if (projects.length === 0) {
+    return (
+      <p
+        className={`rounded-3xl border border-dashed border-stone-300 bg-white p-6 text-stone-600 ${
+          viewMode === "gallery" ? "md:col-span-2" : ""
+        }`}
+      >
+        No projects match your search.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      {projects.map((project) => (
+        <ProjectCard key={project.id} project={project} viewMode={viewMode} />
+      ))}
+    </>
+  );
+}

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -1,0 +1,19 @@
+type SearchInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export function SearchInput({ value, onChange }: SearchInputProps) {
+  return (
+    <label className="space-y-2">
+      <span className="text-sm font-medium text-stone-700">Search</span>
+      <input
+        className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+        onChange={(event) => onChange(event.target.value)}
+        placeholder="Title, tech, author..."
+        type="search"
+        value={value}
+      />
+    </label>
+  );
+}

--- a/app/components/SortSelect.tsx
+++ b/app/components/SortSelect.tsx
@@ -1,0 +1,20 @@
+type SortSelectProps = {
+  value: "date" | "likes";
+  onChange: (value: "date" | "likes") => void;
+};
+
+export function SortSelect({ value, onChange }: SortSelectProps) {
+  return (
+    <label className="space-y-2">
+      <span className="text-sm font-medium text-stone-700">Sort</span>
+      <select
+        className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+        onChange={(event) => onChange(event.target.value as "date" | "likes")}
+        value={value}
+      >
+        <option value="date">Date</option>
+        <option value="likes">Likes</option>
+      </select>
+    </label>
+  );
+}

--- a/app/components/TagFilters.tsx
+++ b/app/components/TagFilters.tsx
@@ -1,0 +1,21 @@
+type TagFiltersProps = {
+  tags: string[];
+};
+
+export function TagFilters({ tags }: TagFiltersProps) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium text-stone-700">Tags filters</p>
+      <div className="flex flex-wrap gap-2">
+        {tags.map((tag) => (
+          <span
+            className="rounded-full border border-stone-300 bg-white px-4 py-2 text-sm text-stone-700"
+            key={tag}
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/TagFilters.tsx
+++ b/app/components/TagFilters.tsx
@@ -1,19 +1,31 @@
 type TagFiltersProps = {
   tags: string[];
+  selectedTags: string[];
+  onToggleTag: (tag: string) => void;
 };
 
-export function TagFilters({ tags }: TagFiltersProps) {
+export function TagFilters({
+  tags,
+  selectedTags,
+  onToggleTag,
+}: TagFiltersProps) {
   return (
     <div className="space-y-3">
       <p className="text-sm font-medium text-stone-700">Tags filters</p>
       <div className="flex flex-wrap gap-2">
         {tags.map((tag) => (
-          <span
-            className="rounded-full border border-stone-300 bg-white px-4 py-2 text-sm text-stone-700"
+          <button
+            className={`rounded-full border px-4 py-2 text-sm transition ${
+              selectedTags.includes(tag)
+                ? "border-stone-950 bg-stone-950 text-white"
+                : "border-stone-300 bg-white text-stone-700 hover:border-stone-950 hover:text-stone-950"
+            }`}
             key={tag}
+            onClick={() => onToggleTag(tag)}
+            type="button"
           >
             {tag}
-          </span>
+          </button>
         ))}
       </div>
     </div>

--- a/app/components/ViewModeToggle.tsx
+++ b/app/components/ViewModeToggle.tsx
@@ -1,0 +1,67 @@
+type ViewModeToggleProps = {
+  value: "gallery" | "list";
+  onChange: (value: "gallery" | "list") => void;
+};
+
+export function ViewModeToggle({ value, onChange }: ViewModeToggleProps) {
+  return (
+    <div className="inline-flex self-start items-center rounded-2xl border border-stone-300 bg-white p-1 shadow-sm">
+      <button
+        aria-label="Gallery view"
+        className={`rounded-xl p-2 transition ${
+          value === "gallery"
+            ? "bg-stone-950 text-white"
+            : "text-stone-600 hover:text-stone-950"
+        }`}
+        onClick={() => onChange("gallery")}
+        title="Gallery view"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="size-5"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.8"
+          viewBox="0 0 24 24"
+        >
+          <rect height="7" rx="1.5" width="7" x="3" y="3" />
+          <rect height="7" rx="1.5" width="7" x="14" y="3" />
+          <rect height="7" rx="1.5" width="7" x="3" y="14" />
+          <rect height="7" rx="1.5" width="7" x="14" y="14" />
+        </svg>
+      </button>
+      <button
+        aria-label="List view"
+        className={`rounded-xl p-2 transition ${
+          value === "list"
+            ? "bg-stone-950 text-white"
+            : "text-stone-600 hover:text-stone-950"
+        }`}
+        onClick={() => onChange("list")}
+        title="List view"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="size-5"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.8"
+          viewBox="0 0 24 24"
+        >
+          <line x1="8" x2="21" y1="6" y2="6" />
+          <line x1="8" x2="21" y1="12" y2="12" />
+          <line x1="8" x2="21" y1="18" y2="18" />
+          <circle cx="4.5" cy="6" r="1.5" />
+          <circle cx="4.5" cy="12" r="1.5" />
+          <circle cx="4.5" cy="18" r="1.5" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -18,6 +18,7 @@ export function meta(_args: Route.MetaArgs) {
 export default function Home() {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState<"date" | "likes">("date");
+  const [viewMode, setViewMode] = useState<"gallery" | "list">("gallery");
   const normalizedQuery = searchQuery.trim().toLowerCase();
   const projects = getAllProjects()
     .filter((project) => {
@@ -38,11 +39,11 @@ export default function Home() {
       return searchableText.includes(normalizedQuery);
     })
     .sort((a, b) => {
-    if (sortBy === "likes") {
-      return b.likes - a.likes;
-    }
+      if (sortBy === "likes") {
+        return b.likes - a.likes;
+      }
 
-    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
 
   return (
@@ -83,26 +84,101 @@ export default function Home() {
       </section>
 
       <section className="space-y-3">
-        <p className="text-sm font-medium text-stone-700">Tags filters</p>
-        <div className="flex flex-wrap gap-2">
-          {featuredTags.map((tag) => (
-            <span
-              className="rounded-full border border-stone-300 bg-white px-4 py-2 text-sm text-stone-700"
-              key={tag}
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-3">
+            <p className="text-sm font-medium text-stone-700">Tags filters</p>
+            <div className="flex flex-wrap gap-2">
+              {featuredTags.map((tag) => (
+                <span
+                  className="rounded-full border border-stone-300 bg-white px-4 py-2 text-sm text-stone-700"
+                  key={tag}
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="inline-flex self-start rounded-2xl border border-stone-300 bg-white p-1 shadow-sm items-center">
+            <button
+              aria-label="Gallery view"
+              className={`rounded-xl p-2 transition ${
+                viewMode === "gallery"
+                  ? "bg-stone-950 text-white"
+                  : "text-stone-600 hover:text-stone-950"
+              }`}
+              onClick={() => setViewMode("gallery")}
+              title="Gallery view"
+              type="button"
             >
-              {tag}
-            </span>
-          ))}
+              <svg
+                aria-hidden="true"
+                className="size-5"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.8"
+                viewBox="0 0 24 24"
+              >
+                <rect height="7" rx="1.5" width="7" x="3" y="3" />
+                <rect height="7" rx="1.5" width="7" x="14" y="3" />
+                <rect height="7" rx="1.5" width="7" x="3" y="14" />
+                <rect height="7" rx="1.5" width="7" x="14" y="14" />
+              </svg>
+            </button>
+            <button
+              aria-label="List view"
+              className={`rounded-xl p-2 transition ${
+                viewMode === "list"
+                  ? "bg-stone-950 text-white"
+                  : "text-stone-600 hover:text-stone-950"
+              }`}
+              onClick={() => setViewMode("list")}
+              title="List view"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                className="size-5"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.8"
+                viewBox="0 0 24 24"
+              >
+                <line x1="8" x2="21" y1="6" y2="6" />
+                <line x1="8" x2="21" y1="12" y2="12" />
+                <line x1="8" x2="21" y1="18" y2="18" />
+                <circle cx="4.5" cy="6" r="1.5" />
+                <circle cx="4.5" cy="12" r="1.5" />
+                <circle cx="4.5" cy="18" r="1.5" />
+              </svg>
+            </button>
+          </div>
         </div>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-2">
+      <section
+        className={
+          viewMode === "gallery" ? "grid gap-4 md:grid-cols-2" : "space-y-4"
+        }
+      >
         {projects.length > 0 ? (
           projects.map((project) => (
-            <ProjectCard key={project.id} project={project} />
+            <ProjectCard
+              key={project.id}
+              project={project}
+              viewMode={viewMode}
+            />
           ))
         ) : (
-          <p className="rounded-3xl border border-dashed border-stone-300 bg-white p-6 text-stone-600 md:col-span-2">
+          <p
+            className={`rounded-3xl border border-dashed border-stone-300 bg-white p-6 text-stone-600 ${
+              viewMode === "gallery" ? "md:col-span-2" : ""
+            }`}
+          >
             No projects match your search.
           </p>
         )}

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,6 +1,10 @@
 import type { Route } from "./+types/home";
 import { useState } from "react";
-import { ProjectCard } from "~/components/ProjectCard";
+import { ProjectList } from "~/components/ProjectList";
+import { SearchInput } from "~/components/SearchInput";
+import { SortSelect } from "~/components/SortSelect";
+import { TagFilters } from "~/components/TagFilters";
+import { ViewModeToggle } from "~/components/ViewModeToggle";
 import { getAllProjects } from "~/data/fakeApiFetch";
 
 const featuredTags = ["React", "TypeScript", "Node.js", "MySQL", "UI"];
@@ -57,106 +61,14 @@ export default function Home() {
       </header>
 
       <section className="grid gap-4 rounded-3xl border border-stone-200 bg-white p-6 shadow-sm md:grid-cols-2">
-        <label className="space-y-2">
-          <span className="text-sm font-medium text-stone-700">Search</span>
-          <input
-            className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Title, tech, author..."
-            type="search"
-            value={searchQuery}
-          />
-        </label>
-
-        <label className="space-y-2">
-          <span className="text-sm font-medium text-stone-700">Sort</span>
-          <select
-            className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
-            onChange={(event) =>
-              setSortBy(event.target.value as "date" | "likes")
-            }
-            value={sortBy}
-          >
-            <option value="date">Date</option>
-            <option value="likes">Likes</option>
-          </select>
-        </label>
+        <SearchInput onChange={setSearchQuery} value={searchQuery} />
+        <SortSelect onChange={setSortBy} value={sortBy} />
       </section>
 
       <section className="space-y-3">
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-          <div className="space-y-3">
-            <p className="text-sm font-medium text-stone-700">Tags filters</p>
-            <div className="flex flex-wrap gap-2">
-              {featuredTags.map((tag) => (
-                <span
-                  className="rounded-full border border-stone-300 bg-white px-4 py-2 text-sm text-stone-700"
-                  key={tag}
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          </div>
-
-          <div className="inline-flex self-start rounded-2xl border border-stone-300 bg-white p-1 shadow-sm items-center">
-            <button
-              aria-label="Gallery view"
-              className={`rounded-xl p-2 transition ${
-                viewMode === "gallery"
-                  ? "bg-stone-950 text-white"
-                  : "text-stone-600 hover:text-stone-950"
-              }`}
-              onClick={() => setViewMode("gallery")}
-              title="Gallery view"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                className="size-5"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="1.8"
-                viewBox="0 0 24 24"
-              >
-                <rect height="7" rx="1.5" width="7" x="3" y="3" />
-                <rect height="7" rx="1.5" width="7" x="14" y="3" />
-                <rect height="7" rx="1.5" width="7" x="3" y="14" />
-                <rect height="7" rx="1.5" width="7" x="14" y="14" />
-              </svg>
-            </button>
-            <button
-              aria-label="List view"
-              className={`rounded-xl p-2 transition ${
-                viewMode === "list"
-                  ? "bg-stone-950 text-white"
-                  : "text-stone-600 hover:text-stone-950"
-              }`}
-              onClick={() => setViewMode("list")}
-              title="List view"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                className="size-5"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="1.8"
-                viewBox="0 0 24 24"
-              >
-                <line x1="8" x2="21" y1="6" y2="6" />
-                <line x1="8" x2="21" y1="12" y2="12" />
-                <line x1="8" x2="21" y1="18" y2="18" />
-                <circle cx="4.5" cy="6" r="1.5" />
-                <circle cx="4.5" cy="12" r="1.5" />
-                <circle cx="4.5" cy="18" r="1.5" />
-              </svg>
-            </button>
-          </div>
+          <TagFilters tags={featuredTags} />
+          <ViewModeToggle onChange={setViewMode} value={viewMode} />
         </div>
       </section>
 
@@ -165,23 +77,7 @@ export default function Home() {
           viewMode === "gallery" ? "grid gap-4 md:grid-cols-2" : "space-y-4"
         }
       >
-        {projects.length > 0 ? (
-          projects.map((project) => (
-            <ProjectCard
-              key={project.id}
-              project={project}
-              viewMode={viewMode}
-            />
-          ))
-        ) : (
-          <p
-            className={`rounded-3xl border border-dashed border-stone-300 bg-white p-6 text-stone-600 ${
-              viewMode === "gallery" ? "md:col-span-2" : ""
-            }`}
-          >
-            No projects match your search.
-          </p>
-        )}
+        <ProjectList projects={projects} viewMode={viewMode} />
       </section>
     </section>
   );

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,4 +1,5 @@
 import type { Route } from "./+types/home";
+import { useState } from "react";
 import { ProjectCard } from "~/components/ProjectCard";
 import { getAllProjects } from "~/data/fakeApiFetch";
 
@@ -15,7 +16,14 @@ export function meta(_args: Route.MetaArgs) {
 }
 
 export default function Home() {
-  const projects = getAllProjects();
+  const [sortBy, setSortBy] = useState<"date" | "likes">("date");
+  const projects = [...getAllProjects()].sort((a, b) => {
+    if (sortBy === "likes") {
+      return b.likes - a.likes;
+    }
+
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
 
   return (
     <section className="space-y-8">
@@ -39,9 +47,15 @@ export default function Home() {
 
         <label className="space-y-2">
           <span className="text-sm font-medium text-stone-700">Sort</span>
-          <select className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950">
-            <option>Date</option>
-            <option>Likes</option>
+          <select
+            className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+            onChange={(event) =>
+              setSortBy(event.target.value as "date" | "likes")
+            }
+            value={sortBy}
+          >
+            <option value="date">Date</option>
+            <option value="likes">Likes</option>
           </select>
         </label>
       </section>

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -16,14 +16,34 @@ export function meta(_args: Route.MetaArgs) {
 }
 
 export default function Home() {
+  const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState<"date" | "likes">("date");
-  const projects = [...getAllProjects()].sort((a, b) => {
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const projects = getAllProjects()
+    .filter((project) => {
+      if (!normalizedQuery) {
+        return true;
+      }
+
+      const searchableText = [
+        project.title,
+        project.summary,
+        project.author.name,
+        project.author.username,
+        ...project.techTags,
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      return searchableText.includes(normalizedQuery);
+    })
+    .sort((a, b) => {
     if (sortBy === "likes") {
       return b.likes - a.likes;
     }
 
     return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-  });
+    });
 
   return (
     <section className="space-y-8">
@@ -40,8 +60,10 @@ export default function Home() {
           <span className="text-sm font-medium text-stone-700">Search</span>
           <input
             className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+            onChange={(event) => setSearchQuery(event.target.value)}
             placeholder="Title, tech, author..."
             type="search"
+            value={searchQuery}
           />
         </label>
 
@@ -75,9 +97,15 @@ export default function Home() {
       </section>
 
       <section className="grid gap-4 md:grid-cols-2">
-        {projects.map((project) => (
-          <ProjectCard key={project.id} project={project} />
-        ))}
+        {projects.length > 0 ? (
+          projects.map((project) => (
+            <ProjectCard key={project.id} project={project} />
+          ))
+        ) : (
+          <p className="rounded-3xl border border-dashed border-stone-300 bg-white p-6 text-stone-600 md:col-span-2">
+            No projects match your search.
+          </p>
+        )}
       </section>
     </section>
   );

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -23,11 +23,14 @@ export default function Home() {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState<"date" | "likes">("date");
   const [viewMode, setViewMode] = useState<"gallery" | "list">("gallery");
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const normalizedQuery = searchQuery.trim().toLowerCase();
   const projects = getAllProjects()
     .filter((project) => {
       if (!normalizedQuery) {
-        return true;
+        return selectedTags.length === 0
+          ? true
+          : selectedTags.some((tag) => project.techTags.includes(tag));
       }
 
       const searchableText = [
@@ -40,7 +43,13 @@ export default function Home() {
         .join(" ")
         .toLowerCase();
 
-      return searchableText.includes(normalizedQuery);
+      const matchesSearch = searchableText.includes(normalizedQuery);
+      const matchesTags =
+        selectedTags.length === 0
+          ? true
+          : selectedTags.some((tag) => project.techTags.includes(tag));
+
+      return matchesSearch && matchesTags;
     })
     .sort((a, b) => {
       if (sortBy === "likes") {
@@ -67,7 +76,17 @@ export default function Home() {
 
       <section className="space-y-3">
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-          <TagFilters tags={featuredTags} />
+          <TagFilters
+            onToggleTag={(tag) =>
+              setSelectedTags((currentTags) =>
+                currentTags.includes(tag)
+                  ? currentTags.filter((currentTag) => currentTag !== tag)
+                  : [...currentTags, tag]
+              )
+            }
+            selectedTags={selectedTags}
+            tags={featuredTags}
+          />
           <ViewModeToggle onChange={setViewMode} value={viewMode} />
         </div>
       </section>

--- a/app/routes/projects/projectDetail.tsx
+++ b/app/routes/projects/projectDetail.tsx
@@ -1,0 +1,134 @@
+import { Link, useLoaderData } from "react-router";
+
+import type { Route } from "./+types/projectDetail";
+import { getProjectById } from "~/data/fakeApiFetch";
+
+export function meta({ data }: Route.MetaArgs) {
+  return [
+    {
+      title: data?.project
+        ? `${data.project.title} | DemoDeck`
+        : "Project | DemoDeck",
+    },
+    {
+      name: "description",
+      content:
+        "Project detail page, with project information and author information.",
+    },
+  ];
+}
+
+export function loader({ params }: Route.LoaderArgs) {
+  const project = getProjectById(params.id);
+
+  if (!project) {
+    throw new Response("Project not found", { status: 404 });
+  }
+
+  return { project };
+}
+
+export default function ProjectDetail() {
+  const { project } = useLoaderData<typeof loader>();
+
+  return (
+    <section className="space-y-8">
+      <header className="space-y-4">
+        <Link
+          className="text-sm font-medium text-stone-600 hover:text-stone-950"
+          to="/"
+        >
+          Back to gallery
+        </Link>
+        <div className="space-y-3">
+          <h1 className="text-4xl font-semibold tracking-tight text-stone-950">
+            {project.title}
+          </h1>
+          <p className="max-w-3xl text-base leading-7 text-stone-600">
+            {project.summary}
+          </p>
+        </div>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[1.4fr_0.6fr]">
+        <article className="rounded-3xl border border-stone-200 bg-white p-8 shadow-sm">
+          <div className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <InfoBlock label="Author" value={project.author.name} />
+              <InfoBlock label="Published" value={project.createdAt} />
+              <InfoBlock label="Likes" value={`${project.likes}`} />
+              <InfoBlock label="Image URL" value={project.imageUrl} />
+            </div>
+
+            <div>
+              <p className="text-sm font-medium text-stone-700">Tech tags</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {project.techTags.map((tag) => (
+                  <span
+                    className="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700"
+                    key={tag}
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <a
+                className="rounded-full bg-stone-950 px-4 py-2 text-sm font-medium text-white"
+                href={project.demoUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                Open demo
+              </a>
+              <a
+                className="rounded-full border border-stone-300 px-4 py-2 text-sm font-medium text-stone-700"
+                href={project.repoUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                Open GitHub
+              </a>
+              <Link
+                className="rounded-full border border-stone-300 px-4 py-2 text-sm font-medium text-stone-700"
+                to={`/projects/${project.id}/edit`}
+              >
+                Edit project
+              </Link>
+            </div>
+          </div>
+        </article>
+
+        <aside className="space-y-4">
+          <div className="rounded-3xl border border-stone-200 bg-white p-6 shadow-sm">
+            <h2 className="mt-3 text-2xl font-semibold tracking-tight text-stone-950">
+              {project.author.name}
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-stone-600">
+              {project.author.bio}
+            </p>
+            <Link
+              className="mt-5 inline-flex text-sm font-medium text-stone-950 hover:underline"
+              to={`/authors/${project.author.id}`}
+            >
+              Open author profile
+            </Link>
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function InfoBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl bg-stone-100 p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-stone-500">
+        {label}
+      </p>
+      <p className="mt-2 break-all text-sm text-stone-700">{value}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This PR improves project browsing on the home page and adds a dedicated project detail page.

Users can now sort, search, filter by tags, and switch between gallery and list views when exploring projects. The home page was also refactored into smaller reusable components to make the code easier to maintain.

## Changes

- Added sorting on the home page by:
  - date
  - likes
- Added search support for:
  - project title
  - project summary
  - author name
  - author username
  - tech tags
- Added clickable tag filters to refine the displayed projects
- Added a gallery/list view toggle
- Updated `ProjectCard` to support both gallery and list display modes
- Added a `ProjectList` component to render the project collection
- Extracted home page controls into dedicated components:
  - `SearchInput`
  - `SortSelect`
  - `TagFilters`
  - `ViewModeToggle`
- Added the project detail page

## Testing

- Ran `npm run typecheck`