### PR TITLE
Feature/login page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 # React Router
 /.react-router/
 /build/
+
+.idea

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="-2f722ec1:19a58408d13:-7ffe" />
+      </MTProjectMetadataState>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="38aab75a-64ac-45af-bc0d-fa5ac6bf0152" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/app/components/AuthScreen.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/AuthScreen.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ProjectCard.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectCard.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ProjectList.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectList.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/lib/auth.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/lib/auth.server.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/root.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/root.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/auth/login.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/auth/login.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/home.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/home.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/projects/projectDetail.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/projects/projectDetail.tsx" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GitToolBoxStore">
+    <option name="recentBranches">
+      <RecentBranches>
+        <option name="branchesForRepo">
+          <list>
+            <RecentBranchesForRepo>
+              <option name="branches">
+                <list>
+                  <RecentBranch>
+                    <option name="branchName" value="feature/login-page" />
+                    <option name="lastUsedInstant" value="1773221263" />
+                  </RecentBranch>
+                  <RecentBranch>
+                    <option name="branchName" value="develop" />
+                    <option name="lastUsedInstant" value="1773221262" />
+                  </RecentBranch>
+                </list>
+              </option>
+              <option name="repositoryRootUrl" value="file://$PROJECT_DIR$" />
+            </RecentBranchesForRepo>
+          </list>
+        </option>
+      </RecentBranches>
+    </option>
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 0
+}</component>
+  <component name="ProjectId" id="3AnGD7MkMXJ9nahlwRCrZjD6QTF" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "git-widget-placeholder": "feature/login-page",
+    "javascript.preferred.runtime.type.id": "node",
+    "last_opened_file_path": "/Users/julienschneider/Desktop/cpnv/S7/PRW3/prw3-demodeck",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "ts.external.directory.path": "/Users/julienschneider/Desktop/cpnv/S7/PRW3/prw3-demodeck/node_modules/typescript/lib",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-9b0f141eb926-JavaScript-WS-253.30387.83" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="38aab75a-64ac-45af-bc0d-fa5ac6bf0152" name="Changes" comment="" />
+      <created>1773220798911</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1773220798911</updated>
+      <workItem from="1773220799929" duration="1341000" />
+      <workItem from="1773222165802" duration="905000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,143 @@ npm run dev
 
 Your application will be available at `http://localhost:5173`.
 
+## Backend Authentication Integration
+
+The current login flow is mocked so the frontend can already handle:
+
+- login form submission
+- auth error display
+- JWT persistence in local storage
+- Redux auth state updates
+- protected-route checks through the auth cookie
+
+Current demo credentials:
+
+```txt
+identifier: student
+password: password
+```
+
+### Files involved
+
+- `app/lib/auth.server.ts`
+- `app/lib/auth.client.ts`
+- `app/routes/auth/login.tsx`
+- `app/components/AuthScreen.tsx`
+- `app/state/auth/authSlice.ts`
+- `app/root.tsx`
+
+### Current flow
+
+1. The login form submits to the route action in `app/routes/auth/login.tsx`.
+2. The action calls `authenticateUser(...)` from `app/lib/auth.server.ts`.
+3. On success, the action returns:
+   - `token`
+   - `user`
+   - `redirectTo`
+4. `AuthScreen` stores the token in local storage with `auth.client.ts`.
+5. `AuthScreen` dispatches `setCredentials(...)` to Redux.
+6. `root.tsx` restores auth state from storage after reload.
+
+### How to connect the real backend
+
+Replace the mock implementation inside `authenticateUser(...)` in `app/lib/auth.server.ts`.
+
+Expected return shape:
+
+```ts
+type AuthSession = {
+  token: string;
+  user: {
+    id: string;
+    name: string;
+  };
+};
+```
+
+### Example backend integration
+
+If your backend exposes `POST /auth/login`, `authenticateUser(...)` can become:
+
+```ts
+export async function authenticateUser(identifier: string, password: string) {
+  const response = await fetch(`${process.env.API_URL}/auth/login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ identifier, password }),
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data = await response.json();
+
+  return {
+    token: data.token,
+    user: {
+      id: data.user.id,
+      name: data.user.name,
+    },
+  };
+}
+```
+
+If `authenticateUser(...)` becomes async, also update the login action:
+
+```ts
+const session = await authenticateUser(identifier, password);
+```
+
+### Backend response contract
+
+To avoid changing the frontend, the backend login response should provide at least:
+
+```json
+{
+  "token": "jwt-token-here",
+  "user": {
+    "id": "123",
+    "name": "Jane Doe"
+  }
+}
+```
+
+### Token storage options
+
+The current implementation uses both:
+
+- a client-stored token in `localStorage`
+- a server-readable auth cookie for route protection
+
+When the real backend is ready, choose one of these strategies:
+
+1. `HttpOnly` cookie only
+2. JWT in frontend storage
+3. access token + refresh token
+
+For a production app, `HttpOnly` cookie auth is usually safer than storing the JWT in `localStorage`.
+
+### If the backend returns more user fields
+
+If your backend also returns `email`, `role`, or other user data:
+
+1. Extend `AuthState` in `app/state/auth/types.ts`
+2. Update `setCredentials(...)` in `app/state/auth/authSlice.ts`
+3. Update the stored session type in `app/lib/auth.client.ts`
+
+### Recommended next cleanup
+
+Before plugging in the real API, a good next step would be to extract backend calls into:
+
+```txt
+app/lib/auth.api.ts
+```
+
+That keeps route actions and UI logic independent from the backend client.
+
 ## Building for Production
 
 Create a production build:

--- a/README.md
+++ b/README.md
@@ -34,25 +34,34 @@ npm run dev
 
 Your application will be available at `http://localhost:5173`.
 
-## Backend Authentication Integration
+## Authentication
 
-The current login flow is mocked so the frontend can already handle:
+The frontend is now connected to the backend API described in `backend-readme.md`.
 
-- login form submission
-- auth error display
-- JWT persistence in local storage
-- Redux auth state updates
-- protected-route checks through the auth cookie
+### Backend URL
 
-Current demo credentials:
+By default, the frontend calls:
 
 ```txt
-identifier: student
-password: password
+http://localhost:3000
 ```
+
+The value is read in `app/lib/backend.server.ts`.
+
+### Demo credentials
+
+After seeding the backend, you can log in with:
+
+```txt
+username: alice
+password: demo-alice
+```
+
+Other seeded accounts from the backend README also work.
 
 ### Files involved
 
+- `app/lib/backend.server.ts`
 - `app/lib/auth.server.ts`
 - `app/lib/auth.client.ts`
 - `app/routes/auth/login.tsx`
@@ -60,26 +69,58 @@ password: password
 - `app/state/auth/authSlice.ts`
 - `app/root.tsx`
 
-### Current flow
+### Current auth flow
 
-1. The login form submits to the route action in `app/routes/auth/login.tsx`.
+1. The login form posts to the route action in `app/routes/auth/login.tsx`.
 2. The action calls `authenticateUser(...)` from `app/lib/auth.server.ts`.
-3. On success, the action returns:
-   - `token`
-   - `user`
-   - `redirectTo`
-4. `AuthScreen` stores the token in local storage with `auth.client.ts`.
-5. `AuthScreen` dispatches `setCredentials(...)` to Redux.
-6. `root.tsx` restores auth state from storage after reload.
+3. `authenticateUser(...)` sends `POST /api/login` to the backend with:
 
-### How to connect the real backend
+```json
+{
+  "username": "alice",
+  "password": "demo-alice"
+}
+```
 
-Replace the mock implementation inside `authenticateUser(...)` in `app/lib/auth.server.ts`.
+4. The frontend accepts the backend login response in this shape:
 
-Expected return shape:
+```json
+{
+  "token": "jwt-token-here",
+  "expiresIn": "1h",
+  "user": {
+    "id": 1,
+    "username": "alice",
+    "name": "Alice"
+  }
+}
+```
+
+5. If needed, the frontend also resolves the current user via `GET /api/me`, which is accepted in this shape:
+
+```json
+{
+  "user": {
+    "id": 1,
+    "username": "alice",
+    "name": "Alice"
+  }
+}
+```
+
+6. On success, the frontend:
+   - sets an `HttpOnly` session cookie for SSR route checks
+   - stores `{ token, user }` in `localStorage`
+   - updates Redux auth state
+
+7. On reload, `app/root.tsx` restores auth state from `localStorage` only if the stored session matches the expected runtime shape. Invalid or stale entries are removed automatically.
+
+### Stored session shape
+
+The client stores this payload under `demodeck_auth_session`:
 
 ```ts
-type AuthSession = {
+type StoredAuthSession = {
   token: string;
   user: {
     id: string;
@@ -88,88 +129,11 @@ type AuthSession = {
 };
 ```
 
-### Example backend integration
+### Notes
 
-If your backend exposes `POST /auth/login`, `authenticateUser(...)` can become:
-
-```ts
-export async function authenticateUser(identifier: string, password: string) {
-  const response = await fetch(`${process.env.API_URL}/auth/login`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ identifier, password }),
-  });
-
-  if (!response.ok) {
-    return null;
-  }
-
-  const data = await response.json();
-
-  return {
-    token: data.token,
-    user: {
-      id: data.user.id,
-      name: data.user.name,
-    },
-  };
-}
-```
-
-If `authenticateUser(...)` becomes async, also update the login action:
-
-```ts
-const session = await authenticateUser(identifier, password);
-```
-
-### Backend response contract
-
-To avoid changing the frontend, the backend login response should provide at least:
-
-```json
-{
-  "token": "jwt-token-here",
-  "user": {
-    "id": "123",
-    "name": "Jane Doe"
-  }
-}
-```
-
-### Token storage options
-
-The current implementation uses both:
-
-- a client-stored token in `localStorage`
-- a server-readable auth cookie for route protection
-
-When the real backend is ready, choose one of these strategies:
-
-1. `HttpOnly` cookie only
-2. JWT in frontend storage
-3. access token + refresh token
-
-For a production app, `HttpOnly` cookie auth is usually safer than storing the JWT in `localStorage`.
-
-### If the backend returns more user fields
-
-If your backend also returns `email`, `role`, or other user data:
-
-1. Extend `AuthState` in `app/state/auth/types.ts`
-2. Update `setCredentials(...)` in `app/state/auth/authSlice.ts`
-3. Update the stored session type in `app/lib/auth.client.ts`
-
-### Recommended next cleanup
-
-Before plugging in the real API, a good next step would be to extract backend calls into:
-
-```txt
-app/lib/auth.api.ts
-```
-
-That keeps route actions and UI logic independent from the backend client.
+- `isAuthenticated(request)` checks the session cookie and validates it against `GET /api/me`.
+- A login failure message can mean either wrong credentials or an unreachable/misconfigured backend URL.
+- For this project, auth requests are made on the server side through React Router actions/loaders, not directly from React components.
 
 ## Building for Production
 
@@ -219,6 +183,3 @@ Make sure to deploy the output of `npm run build`
 
 This template comes with [Tailwind CSS](https://tailwindcss.com/) already configured for a simple default starting experience. You can use whatever CSS framework you prefer.
 
----
-
-Built with ❤️ using React Router.

--- a/app/components/AuthScreen.tsx
+++ b/app/components/AuthScreen.tsx
@@ -94,10 +94,10 @@ export function AuthScreen({
           <input name="redirectTo" type="hidden" value={redirectTo} />
 
           <label className="block space-y-2">
-            <span className="text-sm font-medium text-stone-700">Email</span>
+            <span className="text-sm font-medium text-stone-700">Username</span>
             <input
               className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
-              defaultValue="student"
+              defaultValue="alice"
               name="identifier"
               type="text"
             />
@@ -107,7 +107,7 @@ export function AuthScreen({
             <span className="text-sm font-medium text-stone-700">Password</span>
             <input
               className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
-              defaultValue="password"
+              defaultValue="demo-alice"
               name="password"
               type="password"
             />

--- a/app/components/AuthScreen.tsx
+++ b/app/components/AuthScreen.tsx
@@ -1,0 +1,143 @@
+import { useEffect } from "react";
+import {
+  Form,
+  Link,
+  useFetcher,
+  useNavigate,
+  useNavigation,
+  useSearchParams,
+} from "react-router";
+
+import { useAppDispatch } from "~/config/hooks";
+import {
+  clearStoredAuthSession,
+  saveAuthSession,
+  type StoredAuthSession,
+} from "~/lib/auth.client";
+import { setCredentials, setLoading } from "~/state/auth/authSlice";
+
+type AuthScreenProps = {
+  title: string;
+  submitLabel: string;
+  alternateLabel: string;
+  alternateHref: string;
+  alternatePrompt: string;
+  enableClientAuth?: boolean;
+};
+
+export function AuthScreen({
+  title,
+  submitLabel,
+  alternateLabel,
+  alternateHref,
+  alternatePrompt,
+  enableClientAuth = false,
+}: AuthScreenProps) {
+  const dispatch = useAppDispatch();
+  const fetcher = useFetcher<{
+    error?: string;
+    redirectTo?: string;
+    success?: boolean;
+    token?: string;
+    user?: StoredAuthSession["user"];
+  }>();
+  const navigate = useNavigate();
+  const navigation = useNavigation();
+  const [searchParams] = useSearchParams();
+  const redirectTo = searchParams.get("redirectTo") ?? "/";
+  const FormComponent = enableClientAuth ? fetcher.Form : Form;
+  const isSubmitting = enableClientAuth
+    ? fetcher.state !== "idle"
+    : navigation.state === "submitting";
+  const errorMessage = enableClientAuth ? fetcher.data?.error : null;
+
+  useEffect(() => {
+    if (!enableClientAuth) {
+      return;
+    }
+
+    dispatch(setLoading(isSubmitting));
+  }, [dispatch, enableClientAuth, isSubmitting]);
+
+  useEffect(() => {
+    if (!enableClientAuth || !fetcher.data?.success) {
+      return;
+    }
+
+    if (!fetcher.data.token || !fetcher.data.user || !fetcher.data.redirectTo) {
+      clearStoredAuthSession();
+      return;
+    }
+
+    saveAuthSession({
+      token: fetcher.data.token,
+      user: fetcher.data.user,
+    });
+    dispatch(
+      setCredentials({
+        id: fetcher.data.user.id,
+        name: fetcher.data.user.name,
+        token: fetcher.data.token,
+      }),
+    );
+    navigate(fetcher.data.redirectTo);
+  }, [dispatch, enableClientAuth, fetcher.data, navigate]);
+
+  return (
+    <section className="mx-auto grid max-w-5xl gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+      <div className="rounded-3xl border border-stone-200 bg-stone-950 p-8 text-stone-50 shadow-sm">
+        <h1 className="mt-4 text-4xl font-semibold tracking-tight">{title}</h1>
+      </div>
+
+      <div className="rounded-3xl border border-stone-200 bg-white p-8 shadow-sm">
+        <FormComponent className="space-y-5" method="post">
+          <input name="redirectTo" type="hidden" value={redirectTo} />
+
+          <label className="block space-y-2">
+            <span className="text-sm font-medium text-stone-700">Email</span>
+            <input
+              className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+              defaultValue="student"
+              name="identifier"
+              type="text"
+            />
+          </label>
+
+          <label className="block space-y-2">
+            <span className="text-sm font-medium text-stone-700">Password</span>
+            <input
+              className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+              defaultValue="password"
+              name="password"
+              type="password"
+            />
+          </label>
+
+          {errorMessage ? (
+            <p className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {errorMessage}
+            </p>
+          ) : null}
+
+          <button
+            className="w-full rounded-2xl bg-stone-950 px-5 py-3 font-medium text-white transition hover:bg-stone-800 disabled:cursor-not-allowed disabled:bg-stone-500"
+            disabled={isSubmitting}
+            type="submit"
+          >
+            {isSubmitting ? "Processing..." : submitLabel}
+          </button>
+        </FormComponent>
+
+        <p className="mt-6 text-sm text-stone-600">
+          {alternatePrompt}{" "}
+          <Link
+            className="font-medium text-stone-950 underline underline-offset-4"
+            to={alternateHref}
+          >
+            {alternateLabel}
+          </Link>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/app/components/ProjectCard.tsx
+++ b/app/components/ProjectCard.tsx
@@ -1,9 +1,9 @@
 import { Link } from "react-router";
 
-import type { DemoProjectWithAuthor } from "~/data/fakeData";
+import type { ProjectWithAuthor } from "~/lib/projects";
 
 type ProjectCardProps = {
-  project: DemoProjectWithAuthor;
+  project: ProjectWithAuthor;
   viewMode?: "gallery" | "list";
 };
 

--- a/app/components/ProjectList.tsx
+++ b/app/components/ProjectList.tsx
@@ -1,8 +1,8 @@
 import { ProjectCard } from "~/components/ProjectCard";
-import type { DemoProjectWithAuthor } from "~/data/fakeData";
+import type { ProjectWithAuthor } from "~/lib/projects";
 
 type ProjectListProps = {
-  projects: DemoProjectWithAuthor[];
+  projects: ProjectWithAuthor[];
   viewMode: "gallery" | "list";
 };
 

--- a/app/lib/auth.client.ts
+++ b/app/lib/auth.client.ts
@@ -28,7 +28,14 @@ export function getStoredAuthSession() {
   }
 
   try {
-    return JSON.parse(rawSession) as StoredAuthSession;
+    const parsedSession = JSON.parse(rawSession);
+
+    if (!isStoredAuthSession(parsedSession)) {
+      window.localStorage.removeItem(AUTH_STORAGE_KEY);
+      return null;
+    }
+
+    return parsedSession;
   } catch {
     window.localStorage.removeItem(AUTH_STORAGE_KEY);
     return null;
@@ -41,4 +48,26 @@ export function clearStoredAuthSession() {
   }
 
   window.localStorage.removeItem(AUTH_STORAGE_KEY);
+}
+
+function isStoredAuthSession(value: unknown): value is StoredAuthSession {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const session = value as Record<string, unknown>;
+  const user =
+    session.user && typeof session.user === "object" && !Array.isArray(session.user)
+      ? (session.user as Record<string, unknown>)
+      : null;
+
+  return (
+    typeof session.token === "string" &&
+    session.token.length > 0 &&
+    user !== null &&
+    typeof user.id === "string" &&
+    user.id.length > 0 &&
+    typeof user.name === "string" &&
+    user.name.length > 0
+  );
 }

--- a/app/lib/auth.client.ts
+++ b/app/lib/auth.client.ts
@@ -1,0 +1,44 @@
+export const AUTH_STORAGE_KEY = "demodeck_auth_session";
+
+export type StoredAuthSession = {
+  token: string;
+  user: {
+    id: string;
+    name: string;
+  };
+};
+
+export function saveAuthSession(session: StoredAuthSession) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(session));
+}
+
+export function getStoredAuthSession() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const rawSession = window.localStorage.getItem(AUTH_STORAGE_KEY);
+
+  if (!rawSession) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(rawSession) as StoredAuthSession;
+  } catch {
+    window.localStorage.removeItem(AUTH_STORAGE_KEY);
+    return null;
+  }
+}
+
+export function clearStoredAuthSession() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.removeItem(AUTH_STORAGE_KEY);
+}

--- a/app/lib/auth.server.ts
+++ b/app/lib/auth.server.ts
@@ -1,10 +1,6 @@
+import { asRecord, fetchBackend, readJson, readString } from "./backend.server";
+
 const SESSION_COOKIE_NAME = "demodeck_session";
-const DEMO_AUTH_USER = {
-  id: "student-1",
-  name: "Student Demo",
-  identifier: "student",
-  password: "password",
-};
 
 export type AuthUser = {
   id: string;
@@ -16,37 +12,54 @@ export type AuthSession = {
   user: AuthUser;
 };
 
-export function isAuthenticated(request: Request) {
-  const cookieHeader = request.headers.get("Cookie");
+export async function isAuthenticated(request: Request) {
+  const token = getAuthToken(request);
 
-  if (!cookieHeader) {
+  if (!token) {
     return false;
   }
 
-  return cookieHeader.split(";").some((cookie) => {
-    const [name, value] = cookie.trim().split("=");
-
-    return name === SESSION_COOKIE_NAME && Boolean(value);
-  });
+  const user = await getCurrentUser(token);
+  return user !== null;
 }
 
-export function authenticateUser(identifier: string, password: string) {
-  const normalizedIdentifier = identifier.trim().toLowerCase();
+export async function authenticateUser(identifier: string, password: string) {
+  let response: Response;
 
-  if (
-    normalizedIdentifier !== DEMO_AUTH_USER.identifier ||
-    password !== DEMO_AUTH_USER.password
-  ) {
+  try {
+    response = await fetchBackend("/api/login", {
+      body: JSON.stringify({
+        username: identifier.trim(),
+        password,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+  } catch {
     return null;
   }
 
-  return {
-    token: createFakeJwt(DEMO_AUTH_USER.id),
-    user: {
-      id: DEMO_AUTH_USER.id,
-      name: DEMO_AUTH_USER.name,
-    },
-  } satisfies AuthSession;
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = await readJson<unknown>(response);
+  const payloadRecord = asRecord(payload);
+  const token = readString(payloadRecord?.token);
+
+  if (!token) {
+    return null;
+  }
+
+  const user = parseAuthUser(payloadRecord?.user) ?? (await getCurrentUser(token));
+
+  if (!user) {
+    return null;
+  }
+
+  return { token, user } satisfies AuthSession;
 }
 
 export function createAuthCookie(token: string) {
@@ -69,6 +82,45 @@ export function destroyAuthCookie() {
   ].join("; ");
 }
 
+export function getAuthToken(request: Request) {
+  const cookieHeader = request.headers.get("Cookie");
+
+  if (!cookieHeader) {
+    return null;
+  }
+
+  for (const cookie of cookieHeader.split(";")) {
+    const [name, ...rawValue] = cookie.trim().split("=");
+
+    if (name === SESSION_COOKIE_NAME) {
+      return rawValue.join("=") || null;
+    }
+  }
+
+  return null;
+}
+
+export async function getCurrentUser(token: string) {
+  let response: Response;
+
+  try {
+    response = await fetchBackend("/api/me", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch {
+    return null;
+  }
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = await readJson<unknown>(response);
+  return parseAuthUser(asRecord(payload)?.user ?? payload);
+}
+
 export function getSafeRedirectPath(
   target: FormDataEntryValue | string | null | undefined,
   fallback = "/",
@@ -84,23 +136,17 @@ export function getSafeRedirectPath(
   return target;
 }
 
-function createFakeJwt(subject: string) {
-  const header = toBase64Url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
-  const payload = toBase64Url(
-    JSON.stringify({
-      sub: subject,
-      iat: Math.floor(Date.now() / 1000),
-    }),
-  );
-  const signature = toBase64Url("demodeck-signature");
+function parseAuthUser(value: unknown) {
+  const user = asRecord(value);
+  const id = readString(user?.id) ?? readString(user?.userId);
+  const name =
+    readString(user?.name) ??
+    readString(user?.username) ??
+    readString(user?.email);
 
-  return `${header}.${payload}.${signature}`;
-}
+  if (!id || !name) {
+    return null;
+  }
 
-function toBase64Url(value: string) {
-  return Buffer.from(value)
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/g, "");
+  return { id, name } satisfies AuthUser;
 }

--- a/app/lib/auth.server.ts
+++ b/app/lib/auth.server.ts
@@ -1,0 +1,106 @@
+const SESSION_COOKIE_NAME = "demodeck_session";
+const DEMO_AUTH_USER = {
+  id: "student-1",
+  name: "Student Demo",
+  identifier: "student",
+  password: "password",
+};
+
+export type AuthUser = {
+  id: string;
+  name: string;
+};
+
+export type AuthSession = {
+  token: string;
+  user: AuthUser;
+};
+
+export function isAuthenticated(request: Request) {
+  const cookieHeader = request.headers.get("Cookie");
+
+  if (!cookieHeader) {
+    return false;
+  }
+
+  return cookieHeader.split(";").some((cookie) => {
+    const [name, value] = cookie.trim().split("=");
+
+    return name === SESSION_COOKIE_NAME && Boolean(value);
+  });
+}
+
+export function authenticateUser(identifier: string, password: string) {
+  const normalizedIdentifier = identifier.trim().toLowerCase();
+
+  if (
+    normalizedIdentifier !== DEMO_AUTH_USER.identifier ||
+    password !== DEMO_AUTH_USER.password
+  ) {
+    return null;
+  }
+
+  return {
+    token: createFakeJwt(DEMO_AUTH_USER.id),
+    user: {
+      id: DEMO_AUTH_USER.id,
+      name: DEMO_AUTH_USER.name,
+    },
+  } satisfies AuthSession;
+}
+
+export function createAuthCookie(token: string) {
+  return [
+    `${SESSION_COOKIE_NAME}=${token}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    "Max-Age=604800",
+  ].join("; ");
+}
+
+export function destroyAuthCookie() {
+  return [
+    `${SESSION_COOKIE_NAME}=`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    "Max-Age=0",
+  ].join("; ");
+}
+
+export function getSafeRedirectPath(
+  target: FormDataEntryValue | string | null | undefined,
+  fallback = "/",
+) {
+  if (typeof target !== "string") {
+    return fallback;
+  }
+
+  if (!target.startsWith("/") || target.startsWith("//")) {
+    return fallback;
+  }
+
+  return target;
+}
+
+function createFakeJwt(subject: string) {
+  const header = toBase64Url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = toBase64Url(
+    JSON.stringify({
+      sub: subject,
+      iat: Math.floor(Date.now() / 1000),
+    }),
+  );
+  const signature = toBase64Url("demodeck-signature");
+
+  return `${header}.${payload}.${signature}`;
+}
+
+function toBase64Url(value: string) {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}

--- a/app/lib/backend.server.ts
+++ b/app/lib/backend.server.ts
@@ -1,0 +1,88 @@
+const DEFAULT_BACKEND_API_URL = "http://localhost:3000";
+
+type JsonRecord = Record<string, unknown>;
+
+export function getBackendApiUrl() {
+  return process.env.BACKEND_API_URL ?? DEFAULT_BACKEND_API_URL;
+}
+
+export async function fetchBackend(
+  path: string,
+  init: RequestInit = {},
+) {
+  const url = new URL(path, getBackendApiUrl());
+  const headers = new Headers(init.headers);
+
+  if (!headers.has("Accept")) {
+    headers.set("Accept", "application/json");
+  }
+
+  return fetch(url, {
+    ...init,
+    headers,
+  });
+}
+
+export async function readJson<T>(response: Response) {
+  if (response.status === 204) {
+    return null as T | null;
+  }
+
+  const text = await response.text();
+
+  if (!text) {
+    return null as T | null;
+  }
+
+  return JSON.parse(text) as T;
+}
+
+export function asRecord(value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as JsonRecord;
+}
+
+export function readString(value: unknown) {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  if (typeof value === "bigint") {
+    return String(value);
+  }
+
+  return null;
+}
+
+export function readNumber(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value);
+
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+export function readStringArray(value: unknown) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => readString(item))
+    .filter((item): item is string => item !== null);
+}

--- a/app/lib/projects.server.ts
+++ b/app/lib/projects.server.ts
@@ -1,0 +1,153 @@
+import {
+  asRecord,
+  fetchBackend,
+  readJson,
+  readNumber,
+  readString,
+  readStringArray,
+} from "./backend.server";
+import type { ProjectWithAuthor } from "./projects";
+
+type BackendProject = Record<string, unknown>;
+
+export async function getAllProjects() {
+  let response: Response;
+
+  try {
+    response = await fetchBackend("/api/projects");
+  } catch {
+    throw new Response("Unable to reach the backend projects API.", {
+      status: 502,
+    });
+  }
+
+  if (!response.ok) {
+    throw new Response("Unable to load projects from the backend.", {
+      status: 502,
+    });
+  }
+
+  const payload = await readJson<unknown>(response);
+
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+
+  return payload
+    .map((project) => normalizeProject(project))
+    .filter((project): project is ProjectWithAuthor => project !== null);
+}
+
+export async function getProjectById(projectId: string | undefined) {
+  if (!projectId) {
+    return null;
+  }
+
+  const projects = await getAllProjects();
+  return projects.find((project) => project.id === projectId) ?? null;
+}
+
+function normalizeProject(value: unknown) {
+  const record = asRecord(value);
+
+  if (!record) {
+    return null;
+  }
+
+  const id = readString(record.id) ?? readString(record.projectId);
+  const title = readString(record.title) ?? readString(record.name);
+  const summary =
+    readString(record.summary) ??
+    readString(record.description) ??
+    readString(record.content) ??
+    "";
+  const techTags = readStringArray(
+    record.techTags ?? record.tech_tags ?? record.tags,
+  );
+  const demoUrl =
+    readString(record.demoUrl) ??
+    readString(record.demo_url) ??
+    readString(record.liveUrl) ??
+    readString(record.live_url) ??
+    "#";
+  const repoUrl =
+    readString(record.repoUrl) ??
+    readString(record.repo_url) ??
+    readString(record.githubUrl) ??
+    readString(record.github_url) ??
+    "#";
+  const imageUrl =
+    readString(record.imageUrl) ?? readString(record.image_url) ?? "";
+  const likes =
+    readNumber(record.likes) ??
+    readNumber(record.likesCount) ??
+    readNumber(record.likeCount) ??
+    0;
+  const createdAt = normalizeDate(
+    readString(record.createdAt) ?? readString(record.created_at),
+  );
+  const author = normalizeAuthor(record);
+
+  if (!id || !title || !author) {
+    return null;
+  }
+
+  return {
+    id,
+    title,
+    summary,
+    techTags,
+    demoUrl,
+    repoUrl,
+    imageUrl,
+    likes,
+    createdAt,
+    author,
+  } satisfies ProjectWithAuthor;
+}
+
+function normalizeAuthor(project: BackendProject) {
+  const authorRecord =
+    asRecord(project.author) ??
+    asRecord(project.user) ??
+    asRecord(project.owner) ??
+    null;
+
+  const id =
+    readString(authorRecord?.id) ??
+    readString(authorRecord?.userId) ??
+    readString(project.authorId) ??
+    readString(project.userId);
+
+  if (!id) {
+    return null;
+  }
+
+  const username =
+    readString(authorRecord?.username) ??
+    readString(authorRecord?.login) ??
+    readString(project.authorUsername) ??
+    `user-${id}`;
+  const name =
+    readString(authorRecord?.name) ??
+    readString(authorRecord?.fullName) ??
+    readString(project.authorName) ??
+    username;
+  const bio =
+    readString(authorRecord?.bio) ?? readString(project.authorBio) ?? "";
+
+  return {
+    id,
+    username,
+    name,
+    bio,
+  };
+}
+
+function normalizeDate(value: string | null) {
+  if (!value) {
+    return "Unknown date";
+  }
+
+  return value.length >= 10 ? value.slice(0, 10) : value;
+}

--- a/app/lib/projects.ts
+++ b/app/lib/projects.ts
@@ -1,0 +1,22 @@
+export type ProjectAuthor = {
+  id: string;
+  username: string;
+  name: string;
+  bio: string;
+};
+
+export type Project = {
+  id: string;
+  title: string;
+  summary: string;
+  techTags: string[];
+  demoUrl: string;
+  repoUrl: string;
+  imageUrl: string;
+  likes: number;
+  createdAt: string;
+};
+
+export type ProjectWithAuthor = Project & {
+  author: ProjectAuthor;
+};

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import {
   isRouteErrorResponse,
   Links,
@@ -12,7 +13,10 @@ import { Provider } from "react-redux";
 
 import type { Route } from "./+types/root";
 import "./app.css";
+import { useAppDispatch } from "~/config/hooks";
+import { clearStoredAuthSession, getStoredAuthSession } from "~/lib/auth.client";
 import { destroyAuthCookie, isAuthenticated } from "~/lib/auth.server";
+import { logout, setCredentials } from "~/state/auth/authSlice";
 import { store } from "./config/store";
 import { Navbar } from "./components/Navbar";
 
@@ -65,6 +69,29 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
 export default function App() {
   const { isAuthenticated } = useLoaderData<typeof loader>();
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      clearStoredAuthSession();
+      dispatch(logout());
+      return;
+    }
+
+    const session = getStoredAuthSession();
+
+    if (!session) {
+      return;
+    }
+
+    dispatch(
+      setCredentials({
+        id: session.user.id,
+        name: session.user.name,
+        token: session.token,
+      }),
+    );
+  }, [dispatch, isAuthenticated]);
 
   return (
     <div className="min-h-screen bg-stone-100 text-stone-950">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -34,7 +34,7 @@ export const links: Route.LinksFunction = () => [
 ];
 
 export async function loader({ request }: Route.LoaderArgs) {
-  return { isAuthenticated: isAuthenticated(request) };
+  return { isAuthenticated: await isAuthenticated(request) };
 }
 
 export async function action({ request }: Route.ActionArgs) {

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -3,13 +3,13 @@ import { type RouteConfig, index, layout, route } from "@react-router/dev/routes
 export default [
   index("routes/home.tsx"),
   route("projects/:id", "routes/projects/projectDetail.tsx"),
-  route("authors", "routes/authors/authorsList.tsx"),
-  route("authors/:id", "routes/authors/authorDetail.tsx"),
+  //route("authors", "routes/authors/authorsList.tsx"),
+  //route("authors/:id", "routes/authors/authorDetail.tsx"),
   route("login", "routes/auth/login.tsx"),
-  route("register", "routes/auth/register.tsx"),
-  layout("routes/middleware.tsx", [
-    route("projects/new", "routes/projects/newProject.tsx"),
-    route("projects/:id/edit", "routes/projects/editProject.tsx"),
-  ]),
-  route("*", "routes/notFound.tsx"),
+  //route("register", "routes/auth/register.tsx"),
+  //layout("routes/middleware.tsx", [
+    //route("projects/new", "routes/projects/newProject.tsx"),
+    //route("projects/:id/edit", "routes/projects/editProject.tsx"),
+    //]),
+  //route("*", "routes/notFound.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/auth/login.tsx
+++ b/app/routes/auth/login.tsx
@@ -1,0 +1,80 @@
+import { redirect } from "react-router";
+
+import type { Route } from "./+types/login";
+import { AuthScreen } from "~/components/AuthScreen";
+import {
+  authenticateUser,
+  createAuthCookie,
+  getSafeRedirectPath,
+  isAuthenticated,
+} from "~/lib/auth.server";
+
+export function meta(_args: Route.MetaArgs) {
+  return [
+    { title: "Login | DemoDeck" },
+    {
+      name: "description",
+      content:
+        "User login screen for DemoDeck, with email and password fields.",
+    },
+  ];
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  if (isAuthenticated(request)) {
+    throw redirect("/");
+  }
+
+  return null;
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const formData = await request.formData();
+  const redirectTo = getSafeRedirectPath(formData.get("redirectTo"));
+  const identifier = String(formData.get("identifier") ?? "");
+  const password = String(formData.get("password") ?? "");
+  const session = authenticateUser(identifier, password);
+
+  if (!session) {
+    return new Response(
+      JSON.stringify({
+        error: "Invalid credentials. Try student / password.",
+        success: false,
+      }),
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        status: 401,
+      },
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      redirectTo,
+      success: true,
+      token: session.token,
+      user: session.user,
+    }),
+    {
+      headers: {
+        "Content-Type": "application/json",
+        "Set-Cookie": createAuthCookie(session.token),
+      },
+    },
+  );
+}
+
+export default function Login() {
+  return (
+    <AuthScreen
+      alternateHref="/register"
+      alternateLabel="Create account"
+      alternatePrompt="No account yet?"
+      enableClientAuth
+      submitLabel="Log in"
+      title="Login"
+    />
+  );
+}

--- a/app/routes/auth/login.tsx
+++ b/app/routes/auth/login.tsx
@@ -21,7 +21,7 @@ export function meta(_args: Route.MetaArgs) {
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
-  if (isAuthenticated(request)) {
+  if (await isAuthenticated(request)) {
     throw redirect("/");
   }
 
@@ -33,12 +33,12 @@ export async function action({ request }: Route.ActionArgs) {
   const redirectTo = getSafeRedirectPath(formData.get("redirectTo"));
   const identifier = String(formData.get("identifier") ?? "");
   const password = String(formData.get("password") ?? "");
-  const session = authenticateUser(identifier, password);
+  const session = await authenticateUser(identifier, password);
 
   if (!session) {
     return new Response(
       JSON.stringify({
-        error: "Invalid credentials. Try student / password.",
+        error: "Invalid credentials. Try alice / demo-alice.",
         success: false,
       }),
       {

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,13 +1,12 @@
 import type { Route } from "./+types/home";
+import { useLoaderData } from "react-router";
 import { useState } from "react";
 import { ProjectList } from "~/components/ProjectList";
 import { SearchInput } from "~/components/SearchInput";
 import { SortSelect } from "~/components/SortSelect";
 import { TagFilters } from "~/components/TagFilters";
 import { ViewModeToggle } from "~/components/ViewModeToggle";
-import { getAllProjects } from "~/data/fakeApiFetch";
-
-const featuredTags = ["React", "TypeScript", "Node.js", "MySQL", "UI"];
+import { getAllProjects } from "~/lib/projects.server";
 
 export function meta(_args: Route.MetaArgs) {
   return [
@@ -19,13 +18,22 @@ export function meta(_args: Route.MetaArgs) {
   ];
 }
 
+export async function loader() {
+  const projects = await getAllProjects();
+
+  return {
+    projects,
+  };
+}
+
 export default function Home() {
+  const { projects: allProjects } = useLoaderData<typeof loader>();
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState<"date" | "likes">("date");
   const [viewMode, setViewMode] = useState<"gallery" | "list">("gallery");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const normalizedQuery = searchQuery.trim().toLowerCase();
-  const projects = getAllProjects()
+  const projects = allProjects
     .filter((project) => {
       if (!normalizedQuery) {
         return selectedTags.length === 0
@@ -58,6 +66,7 @@ export default function Home() {
 
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
+  const featuredTags = [...new Set(allProjects.flatMap((project) => project.techTags))];
 
   return (
     <section className="space-y-8">

--- a/app/routes/projects/projectDetail.tsx
+++ b/app/routes/projects/projectDetail.tsx
@@ -1,7 +1,7 @@
 import { Link, useLoaderData } from "react-router";
 
 import type { Route } from "./+types/projectDetail";
-import { getProjectById } from "~/data/fakeApiFetch";
+import { getProjectById } from "~/lib/projects.server";
 
 export function meta({ data }: Route.MetaArgs) {
   return [
@@ -18,8 +18,8 @@ export function meta({ data }: Route.MetaArgs) {
   ];
 }
 
-export function loader({ params }: Route.LoaderArgs) {
-  const project = getProjectById(params.id);
+export async function loader({ params }: Route.LoaderArgs) {
+  const project = await getProjectById(params.id);
 
   if (!project) {
     throw new Response("Project not found", { status: 404 });

--- a/app/state/auth/authSlice.ts
+++ b/app/state/auth/authSlice.ts
@@ -4,6 +4,7 @@ import type { AuthState } from "./types";
 
 const initialState: AuthState = {
   user: null,
+  token: null,
   isAuthenticated: false,
   isLoading: false,
 };
@@ -14,14 +15,18 @@ const authSlice = createSlice({
   reducers: {
     setCredentials: (
       state,
-      action: PayloadAction<{ id: string; name: string }>,
+      action: PayloadAction<{ id: string; name: string; token: string }>,
     ) => {
-      state.user = action.payload;
+      state.user = { id: action.payload.id, name: action.payload.name };
+      state.token = action.payload.token;
       state.isAuthenticated = true;
+      state.isLoading = false;
     },
     logout: (state) => {
       state.user = null;
+      state.token = null;
       state.isAuthenticated = false;
+      state.isLoading = false;
     },
     setLoading: (state, action: PayloadAction<boolean>) => {
       state.isLoading = action.payload;
@@ -32,6 +37,7 @@ const authSlice = createSlice({
 export const { setCredentials, logout, setLoading } = authSlice.actions;
 
 export const selectCurrentUser = (state: RootState) => state.auth.user;
+export const selectCurrentToken = (state: RootState) => state.auth.token;
 export const selectIsAuthenticated = (state: RootState) =>
   state.auth.isAuthenticated;
 

--- a/app/state/auth/types.ts
+++ b/app/state/auth/types.ts
@@ -1,5 +1,6 @@
 export interface AuthState {
   user: { id: string; name: string } | null;
+  token: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
 }


### PR DESCRIPTION
## Summary

This PR implements the login flow foundations for the frontend and documents how to connect the feature to the future backend.

The app now handles login submission, mock authentication, JWT-style token persistence, Redux auth state updates, and auth-state restoration after reload. It also adds documentation explaining how to replace the mock auth layer with a real backend API.

## Changes

- Added mock authentication logic in `app/lib/auth.server.ts`
- Added client-side auth session helpers in `app/lib/auth.client.ts`
- Updated the login flow to:
  - validate credentials
  - return structured success/error responses
  - store the token locally
  - update Redux auth state on success
- Extended the auth slice to store:
  - authenticated user
  - token
  - loading state
- Synced Redux auth state from persisted session data in `app/root.tsx`
- Added inline login error handling in `AuthScreen`
- Added documentation in `README.md` explaining how to connect the auth flow to the backend later

## Demo Credentials

```txt
identifier: student
password: password
```

## Testing

- Ran `npm run typecheck`

## Notes

The current implementation is mocked for frontend integration purposes.  
The backend handoff is documented in `README.md`, including the expected response shape and where to replace the mock authentication logic.