### PR TITLE
Feature/projects crud

### DIFF
--- a/app/components/InfoBlock.tsx
+++ b/app/components/InfoBlock.tsx
@@ -1,0 +1,15 @@
+type InfoBlockProps = {
+  label: string;
+  value: string;
+};
+
+export function InfoBlock({ label, value }: InfoBlockProps) {
+  return (
+    <div className="rounded-2xl bg-stone-100 p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-stone-500">
+        {label}
+      </p>
+      <p className="mt-2 break-all text-sm text-stone-700">{value}</p>
+    </div>
+  );
+}

--- a/app/components/ProjectEditorForm.tsx
+++ b/app/components/ProjectEditorForm.tsx
@@ -1,0 +1,146 @@
+import { Form, Link } from "react-router";
+
+import type { ProjectFormErrors, ProjectFormValues } from "~/lib/project-form";
+
+type ProjectEditorFormProps = {
+  action?: string;
+  cancelHref: string;
+  cancelLabel: string;
+  defaultValues: ProjectFormValues;
+  errors?: ProjectFormErrors;
+  isSubmitting: boolean;
+  submitLabel: string;
+  submittingLabel: string;
+};
+
+export function ProjectEditorForm({
+  action,
+  cancelHref,
+  cancelLabel,
+  defaultValues,
+  errors,
+  isSubmitting,
+  submitLabel,
+  submittingLabel,
+}: ProjectEditorFormProps) {
+  return (
+    <Form
+      action={action}
+      className="grid gap-4 rounded-3xl border border-stone-200 bg-white p-8 shadow-sm"
+      method="post"
+    >
+      {errors?.form && (
+        <div className="rounded-2xl border border-red-100 bg-red-50 p-4 text-sm text-red-600">
+          {errors.form}
+        </div>
+      )}
+
+      <Field
+        defaultValue={defaultValues.title}
+        error={errors?.title}
+        label="Title"
+        name="title"
+        placeholder="My mini-project"
+      />
+      <Field
+        defaultValue={defaultValues.summary}
+        error={errors?.summary}
+        label="Summary"
+        multiline
+        name="summary"
+        placeholder="Explain quickly the purpose of the project, the stack and the value."
+      />
+      <Field
+        defaultValue={defaultValues.techTags}
+        error={errors?.techTags}
+        helperText="Separate tags with commas."
+        label="Technical Tags"
+        name="techTags"
+        placeholder="React, TypeScript, MySQL"
+      />
+      <Field
+        defaultValue={defaultValues.demoUrl}
+        error={errors?.demoUrl}
+        label="Demo URL"
+        name="demoUrl"
+        placeholder="https://demo.example.com"
+      />
+      <Field
+        defaultValue={defaultValues.repoUrl}
+        error={errors?.repoUrl}
+        label="GitHub URL"
+        name="repoUrl"
+        placeholder="https://github.com/me/project"
+      />
+      <Field
+        defaultValue={defaultValues.imageUrl}
+        error={errors?.imageUrl}
+        label="Image URL"
+        name="imageUrl"
+        placeholder="https://images.example.com/cover.jpg"
+      />
+
+      <div className="flex flex-wrap gap-3 pt-2">
+        <button
+          className="rounded-full bg-stone-950 px-5 py-3 font-medium text-white"
+          disabled={isSubmitting}
+          type="submit"
+        >
+          {isSubmitting ? submittingLabel : submitLabel}
+        </button>
+        <Link
+          className="rounded-full border border-stone-300 px-5 py-3 font-medium text-stone-700"
+          to={cancelHref}
+        >
+          {cancelLabel}
+        </Link>
+      </div>
+    </Form>
+  );
+}
+
+function Field({
+  label,
+  name,
+  placeholder,
+  defaultValue,
+  error,
+  helperText,
+  multiline = false,
+}: {
+  label: string;
+  name: keyof ProjectFormValues;
+  placeholder: string;
+  defaultValue?: string;
+  error?: string;
+  helperText?: string;
+  multiline?: boolean;
+}) {
+  return (
+    <label className="space-y-2">
+      <span className="text-sm font-medium text-stone-700">{label}</span>
+
+      {multiline ? (
+        <textarea
+          className="min-h-32 w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+          defaultValue={defaultValue}
+          name={name}
+          placeholder={placeholder}
+        />
+      ) : (
+        <input
+          className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+          defaultValue={defaultValue}
+          name={name}
+          placeholder={placeholder}
+          type="text"
+        />
+      )}
+
+      {helperText && !error && (
+        <p className="text-sm text-stone-500">{helperText}</p>
+      )}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </label>
+  );
+}

--- a/app/components/ProjectOwnerActions.tsx
+++ b/app/components/ProjectOwnerActions.tsx
@@ -1,0 +1,44 @@
+import { Form, Link } from "react-router";
+
+type ProjectOwnerActionsProps = {
+  isDeleting: boolean;
+  projectId: string;
+};
+
+export function ProjectOwnerActions({
+  isDeleting,
+  projectId,
+}: ProjectOwnerActionsProps) {
+  return (
+    <>
+      <Link
+        className="rounded-full border border-stone-300 px-4 py-2 text-sm font-medium text-stone-700"
+        to={`/projects/${projectId}/edit`}
+      >
+        Edit project
+      </Link>
+      <Form
+        action={`/projects/${projectId}`}
+        method="post"
+        onSubmit={(event) => {
+          const isConfirmed = window.confirm(
+            "Delete this project permanently?",
+          );
+
+          if (!isConfirmed) {
+            event.preventDefault();
+          }
+        }}
+      >
+        <input name="_intent" type="hidden" value="delete" />
+        <button
+          className="rounded-full border border-red-200 px-4 py-2 text-sm font-medium text-red-700 transition hover:bg-red-50 disabled:opacity-70"
+          disabled={isDeleting}
+          type="submit"
+        >
+          {isDeleting ? "Deleting..." : "Delete project"}
+        </button>
+      </Form>
+    </>
+  );
+}

--- a/app/lib/project-form.ts
+++ b/app/lib/project-form.ts
@@ -1,0 +1,118 @@
+import type { CreateProjectInput } from "./projects.server";
+import type { ProjectWithAuthor } from "./projects";
+
+export type ProjectFormValues = {
+  title: string;
+  summary: string;
+  techTags: string;
+  demoUrl: string;
+  repoUrl: string;
+  imageUrl: string;
+};
+
+export type ProjectFormErrors = Partial<
+  Record<keyof ProjectFormValues | "form", string>
+>;
+
+export type ProjectFormActionData = {
+  defaultValues: ProjectFormValues;
+  errors: ProjectFormErrors;
+};
+
+export function getEmptyProjectFormValues(): ProjectFormValues {
+  return {
+    title: "",
+    summary: "",
+    techTags: "",
+    demoUrl: "",
+    repoUrl: "",
+    imageUrl: "",
+  };
+}
+
+export function getProjectFormValues(project: ProjectWithAuthor): ProjectFormValues {
+  return {
+    title: project.title,
+    summary: project.summary,
+    techTags: project.techTags.join(", "),
+    demoUrl: project.demoUrl === "#" ? "" : project.demoUrl,
+    repoUrl: project.repoUrl === "#" ? "" : project.repoUrl,
+    imageUrl: project.imageUrl,
+  };
+}
+
+export function readProjectFormValues(formData: FormData): ProjectFormValues {
+  return {
+    title: readFormValue(formData.get("title")),
+    summary: readFormValue(formData.get("summary")),
+    techTags: readFormValue(formData.get("techTags")),
+    demoUrl: readFormValue(formData.get("demoUrl")),
+    repoUrl: readFormValue(formData.get("repoUrl")),
+    imageUrl: readFormValue(formData.get("imageUrl")),
+  };
+}
+
+export function validateProjectForm(values: ProjectFormValues): ProjectFormErrors {
+  const errors: ProjectFormErrors = {};
+
+  if (!values.title) {
+    errors.title = "Title is required.";
+  }
+
+  if (!values.summary) {
+    errors.summary = "Summary is required.";
+  }
+
+  if (parseTechTags(values.techTags).length === 0) {
+    errors.techTags = "Add at least one technical tag.";
+  }
+
+  if (values.demoUrl && !isValidUrl(values.demoUrl)) {
+    errors.demoUrl = "Enter a valid URL.";
+  }
+
+  if (values.repoUrl && !isValidUrl(values.repoUrl)) {
+    errors.repoUrl = "Enter a valid URL.";
+  }
+
+  if (values.imageUrl && !isValidUrl(values.imageUrl)) {
+    errors.imageUrl = "Enter a valid URL.";
+  }
+
+  return errors;
+}
+
+export function hasProjectFormErrors(errors: ProjectFormErrors) {
+  return Object.keys(errors).length > 0;
+}
+
+export function parseTechTags(value: string) {
+  return value
+    .split(/,|\n/)
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+}
+
+export function buildProjectInput(values: ProjectFormValues): CreateProjectInput {
+  return {
+    title: values.title,
+    summary: values.summary,
+    techTags: parseTechTags(values.techTags),
+    ...(values.demoUrl ? { demoUrl: values.demoUrl } : {}),
+    ...(values.repoUrl ? { repoUrl: values.repoUrl } : {}),
+    ...(values.imageUrl ? { imageUrl: values.imageUrl } : {}),
+  };
+}
+
+function readFormValue(value: FormDataEntryValue | null) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isValidUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/app/lib/projects.server.ts
+++ b/app/lib/projects.server.ts
@@ -108,6 +108,48 @@ export async function createProject(
   return createdProject;
 }
 
+export async function updateProject(
+  projectId: string | undefined,
+  project: CreateProjectInput,
+  token: string,
+) {
+  if (!projectId) {
+    throw new ProjectRequestError("Invalid project id.", 400);
+  }
+
+  let response: Response;
+
+  try {
+    response = await fetchBackend(`/api/projects/${projectId}`, {
+      body: JSON.stringify(project),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      method: "PUT",
+    });
+  } catch {
+    throw new ProjectRequestError(
+      "Unable to reach the backend projects API.",
+      502,
+    );
+  }
+
+  if (!response.ok) {
+    throw new ProjectRequestError(
+      await readBackendError(response, "Unable to update the project."),
+      response.status >= 400 ? response.status : 500,
+    );
+  }
+
+  const payload = await readJson<unknown>(response).catch(() => null);
+  const record = asRecord(payload);
+
+  return (
+    readString(record?.id) ?? readString(record?.projectId) ?? projectId
+  );
+}
+
 function normalizeProject(value: unknown) {
   const record = asRecord(value);
 

--- a/app/lib/projects.server.ts
+++ b/app/lib/projects.server.ts
@@ -10,6 +10,25 @@ import type { ProjectWithAuthor } from "./projects";
 
 type BackendProject = Record<string, unknown>;
 
+export type CreateProjectInput = {
+  title: string;
+  summary: string;
+  techTags: string[];
+  demoUrl?: string;
+  repoUrl?: string;
+  imageUrl?: string;
+};
+
+export class ProjectRequestError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ProjectRequestError";
+    this.status = status;
+  }
+}
+
 export async function getAllProjects() {
   let response: Response;
 
@@ -45,6 +64,48 @@ export async function getProjectById(projectId: string | undefined) {
 
   const projects = await getAllProjects();
   return projects.find((project) => project.id === projectId) ?? null;
+}
+
+export async function createProject(
+  project: CreateProjectInput,
+  token: string,
+) {
+  let response: Response;
+
+  try {
+    response = await fetchBackend("/api/projects", {
+      body: JSON.stringify(project),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+  } catch {
+    throw new ProjectRequestError(
+      "Unable to reach the backend projects API.",
+      502,
+    );
+  }
+
+  if (!response.ok) {
+    throw new ProjectRequestError(
+      await readBackendError(response, "Unable to create the project."),
+      response.status >= 400 ? response.status : 500,
+    );
+  }
+
+  const payload = await readJson<unknown>(response);
+  const createdProject = normalizeProject(payload);
+
+  if (!createdProject) {
+    throw new ProjectRequestError(
+      "The backend response is missing project data.",
+      502,
+    );
+  }
+
+  return createdProject;
 }
 
 function normalizeProject(value: unknown) {
@@ -150,4 +211,18 @@ function normalizeDate(value: string | null) {
   }
 
   return value.length >= 10 ? value.slice(0, 10) : value;
+}
+
+async function readBackendError(
+  response: Response,
+  fallbackMessage: string,
+): Promise<string> {
+  const payload = await readJson<unknown>(response).catch(() => null);
+  const record = asRecord(payload);
+
+  return (
+    readString(record?.message) ??
+    readString(record?.error) ??
+    fallbackMessage
+  );
 }

--- a/app/lib/projects.server.ts
+++ b/app/lib/projects.server.ts
@@ -150,6 +150,38 @@ export async function updateProject(
   );
 }
 
+export async function deleteProject(
+  projectId: string | undefined,
+  token: string,
+) {
+  if (!projectId) {
+    throw new ProjectRequestError("Invalid project id.", 400);
+  }
+
+  let response: Response;
+
+  try {
+    response = await fetchBackend(`/api/projects/${projectId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      method: "DELETE",
+    });
+  } catch {
+    throw new ProjectRequestError(
+      "Unable to reach the backend projects API.",
+      502,
+    );
+  }
+
+  if (!response.ok) {
+    throw new ProjectRequestError(
+      await readBackendError(response, "Unable to delete the project."),
+      response.status >= 400 ? response.status : 500,
+    );
+  }
+}
+
 function normalizeProject(value: unknown) {
   const record = asRecord(value);
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -7,9 +7,9 @@ export default [
   //route("authors/:id", "routes/authors/authorDetail.tsx"),
   route("login", "routes/auth/login.tsx"),
   route("register", "routes/auth/register.tsx"),
-  //layout("routes/middleware.tsx", [
-    //route("projects/new", "routes/projects/newProject.tsx"),
-    //route("projects/:id/edit", "routes/projects/editProject.tsx"),
-    //]),
+  layout("routes/middleware.tsx", [
+    route("projects/new", "routes/projects/newProject.tsx"),
+    route("projects/:id/edit", "routes/projects/editProject.tsx"),
+  ]),
   //route("*", "routes/notFound.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/middleware.tsx
+++ b/app/routes/middleware.tsx
@@ -1,0 +1,19 @@
+import { Outlet, redirect } from "react-router";
+
+import type { Route } from "./+types/middleware";
+import { isAuthenticated } from "~/lib/auth.server";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  if (await isAuthenticated(request)) {
+    return null;
+  }
+
+  const url = new URL(request.url);
+  const redirectTo = `${url.pathname}${url.search}`;
+
+  throw redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`);
+}
+
+export default function ProtectedLayout() {
+  return <Outlet />;
+}

--- a/app/routes/projects/editProject.tsx
+++ b/app/routes/projects/editProject.tsx
@@ -1,7 +1,5 @@
 import {
   data,
-  Form,
-  Link,
   redirect,
   useActionData,
   useLoaderData,
@@ -9,31 +7,21 @@ import {
 } from "react-router";
 
 import type { Route } from "./+types/editProject";
+import { ProjectEditorForm } from "~/components/ProjectEditorForm";
 import { getAuthSession } from "~/lib/auth.server";
 import {
   getProjectById,
   ProjectRequestError,
   updateProject,
 } from "~/lib/projects.server";
-import type { ProjectWithAuthor } from "~/lib/projects";
-
-type ProjectFormValues = {
-  title: string;
-  summary: string;
-  techTags: string;
-  demoUrl: string;
-  repoUrl: string;
-  imageUrl: string;
-};
-
-type ProjectFormErrors = Partial<
-  Record<keyof ProjectFormValues | "form", string>
->;
-
-type ActionData = {
-  defaultValues: ProjectFormValues;
-  errors: ProjectFormErrors;
-};
+import {
+  buildProjectInput,
+  getProjectFormValues,
+  hasProjectFormErrors,
+  readProjectFormValues,
+  type ProjectFormActionData,
+  validateProjectForm,
+} from "~/lib/project-form";
 
 export function meta({ data }: Route.MetaArgs) {
   return [
@@ -72,27 +60,16 @@ export async function action({ params, request }: Route.ActionArgs) {
   const defaultValues = readProjectFormValues(formData);
   const errors = validateProjectForm(defaultValues);
 
-  if (hasErrors(errors)) {
-    return data<ActionData>({ defaultValues, errors }, { status: 400 });
+  if (hasProjectFormErrors(errors)) {
+    return data<ProjectFormActionData>({ defaultValues, errors }, { status: 400 });
   }
 
   try {
-    const projectId = await updateProject(
-      params.id,
-      {
-        title: defaultValues.title,
-        summary: defaultValues.summary,
-        techTags: parseTechTags(defaultValues.techTags),
-        ...(defaultValues.demoUrl ? { demoUrl: defaultValues.demoUrl } : {}),
-        ...(defaultValues.repoUrl ? { repoUrl: defaultValues.repoUrl } : {}),
-        ...(defaultValues.imageUrl ? { imageUrl: defaultValues.imageUrl } : {}),
-      },
-      authSession.token,
-    );
+    const projectId = await updateProject(params.id, buildProjectInput(defaultValues), authSession.token);
 
     return redirect(`/projects/${projectId}`);
   } catch (error) {
-    return data<ActionData>(
+    return data<ProjectFormActionData>(
       {
         defaultValues,
         errors: {
@@ -111,7 +88,7 @@ export async function action({ params, request }: Route.ActionArgs) {
 
 export default function EditProject() {
   const { project } = useLoaderData<typeof loader>();
-  const actionData = useActionData<ActionData>();
+  const actionData = useActionData<ProjectFormActionData>();
   const navigation = useNavigation();
   const isSubmitting = navigation.state === "submitting";
   const defaultValues =
@@ -125,200 +102,16 @@ export default function EditProject() {
         </h1>
       </header>
 
-      <Form
+      <ProjectEditorForm
         action={`/projects/${project.id}/edit`}
-        className="grid gap-4 rounded-3xl border border-stone-200 bg-white p-8 shadow-sm"
-        method="post"
-      >
-        {actionData?.errors?.form && (
-          <div className="rounded-2xl border border-red-100 bg-red-50 p-4 text-sm text-red-600">
-            {actionData.errors.form}
-          </div>
-        )}
-
-        <Field
-          defaultValue={defaultValues.title}
-          error={actionData?.errors?.title}
-          label="Title"
-          name="title"
-          placeholder="My mini-project"
-        />
-        <Field
-          defaultValue={defaultValues.summary}
-          error={actionData?.errors?.summary}
-          label="Summary"
-          multiline
-          name="summary"
-          placeholder="Explain quickly the purpose of the project, the stack and the value."
-        />
-        <Field
-          defaultValue={defaultValues.techTags}
-          error={actionData?.errors?.techTags}
-          helperText="Separate tags with commas."
-          label="Technical Tags"
-          name="techTags"
-          placeholder="React, TypeScript, MySQL"
-        />
-        <Field
-          defaultValue={defaultValues.demoUrl}
-          error={actionData?.errors?.demoUrl}
-          label="Demo URL"
-          name="demoUrl"
-          placeholder="https://demo.example.com"
-        />
-        <Field
-          defaultValue={defaultValues.repoUrl}
-          error={actionData?.errors?.repoUrl}
-          label="GitHub URL"
-          name="repoUrl"
-          placeholder="https://github.com/me/project"
-        />
-        <Field
-          defaultValue={defaultValues.imageUrl}
-          error={actionData?.errors?.imageUrl}
-          label="Image URL"
-          name="imageUrl"
-          placeholder="https://images.example.com/cover.jpg"
-        />
-
-        <div className="flex flex-wrap gap-3 pt-2">
-          <button
-            className="rounded-full bg-stone-950 px-5 py-3 font-medium text-white"
-            disabled={isSubmitting}
-            type="submit"
-          >
-            {isSubmitting ? "Saving..." : "Save changes"}
-          </button>
-          <Link
-            className="rounded-full border border-stone-300 px-5 py-3 font-medium text-stone-700"
-            to={`/projects/${project.id}`}
-          >
-            Back to project details
-          </Link>
-        </div>
-      </Form>
+        cancelHref={`/projects/${project.id}`}
+        cancelLabel="Back to project details"
+        defaultValues={defaultValues}
+        errors={actionData?.errors}
+        isSubmitting={isSubmitting}
+        submitLabel="Save changes"
+        submittingLabel="Saving..."
+      />
     </section>
   );
-}
-
-function Field({
-  label,
-  name,
-  placeholder,
-  defaultValue,
-  error,
-  helperText,
-  multiline = false,
-}: {
-  label: string;
-  name: keyof ProjectFormValues;
-  placeholder: string;
-  defaultValue?: string;
-  error?: string;
-  helperText?: string;
-  multiline?: boolean;
-}) {
-  return (
-    <label className="space-y-2">
-      <span className="text-sm font-medium text-stone-700">{label}</span>
-
-      {multiline ? (
-        <textarea
-          className="min-h-32 w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
-          defaultValue={defaultValue}
-          name={name}
-          placeholder={placeholder}
-        />
-      ) : (
-        <input
-          className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
-          defaultValue={defaultValue}
-          name={name}
-          placeholder={placeholder}
-          type="text"
-        />
-      )}
-
-      {helperText && !error && (
-        <p className="text-sm text-stone-500">{helperText}</p>
-      )}
-      {error && <p className="text-sm text-red-600">{error}</p>}
-    </label>
-  );
-}
-
-function getProjectFormValues(project: ProjectWithAuthor): ProjectFormValues {
-  return {
-    title: project.title,
-    summary: project.summary,
-    techTags: project.techTags.join(", "),
-    demoUrl: project.demoUrl === "#" ? "" : project.demoUrl,
-    repoUrl: project.repoUrl === "#" ? "" : project.repoUrl,
-    imageUrl: project.imageUrl,
-  };
-}
-
-function readProjectFormValues(formData: FormData): ProjectFormValues {
-  return {
-    title: readFormValue(formData.get("title")),
-    summary: readFormValue(formData.get("summary")),
-    techTags: readFormValue(formData.get("techTags")),
-    demoUrl: readFormValue(formData.get("demoUrl")),
-    repoUrl: readFormValue(formData.get("repoUrl")),
-    imageUrl: readFormValue(formData.get("imageUrl")),
-  };
-}
-
-function validateProjectForm(values: ProjectFormValues): ProjectFormErrors {
-  const errors: ProjectFormErrors = {};
-
-  if (!values.title) {
-    errors.title = "Title is required.";
-  }
-
-  if (!values.summary) {
-    errors.summary = "Summary is required.";
-  }
-
-  if (parseTechTags(values.techTags).length === 0) {
-    errors.techTags = "Add at least one technical tag.";
-  }
-
-  if (values.demoUrl && !isValidUrl(values.demoUrl)) {
-    errors.demoUrl = "Enter a valid URL.";
-  }
-
-  if (values.repoUrl && !isValidUrl(values.repoUrl)) {
-    errors.repoUrl = "Enter a valid URL.";
-  }
-
-  if (values.imageUrl && !isValidUrl(values.imageUrl)) {
-    errors.imageUrl = "Enter a valid URL.";
-  }
-
-  return errors;
-}
-
-function hasErrors(errors: ProjectFormErrors) {
-  return Object.keys(errors).length > 0;
-}
-
-function parseTechTags(value: string) {
-  return value
-    .split(/,|\n/)
-    .map((tag) => tag.trim())
-    .filter((tag) => tag.length > 0);
-}
-
-function readFormValue(value: FormDataEntryValue | null) {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function isValidUrl(value: string) {
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
 }

--- a/app/routes/projects/editProject.tsx
+++ b/app/routes/projects/editProject.tsx
@@ -1,0 +1,324 @@
+import {
+  data,
+  Form,
+  Link,
+  redirect,
+  useActionData,
+  useLoaderData,
+  useNavigation,
+} from "react-router";
+
+import type { Route } from "./+types/editProject";
+import { getAuthSession } from "~/lib/auth.server";
+import {
+  getProjectById,
+  ProjectRequestError,
+  updateProject,
+} from "~/lib/projects.server";
+import type { ProjectWithAuthor } from "~/lib/projects";
+
+type ProjectFormValues = {
+  title: string;
+  summary: string;
+  techTags: string;
+  demoUrl: string;
+  repoUrl: string;
+  imageUrl: string;
+};
+
+type ProjectFormErrors = Partial<
+  Record<keyof ProjectFormValues | "form", string>
+>;
+
+type ActionData = {
+  defaultValues: ProjectFormValues;
+  errors: ProjectFormErrors;
+};
+
+export function meta({ data }: Route.MetaArgs) {
+  return [
+    {
+      title: data?.project
+        ? `Edit ${data.project.title} | DemoDeck`
+        : "Edit project | DemoDeck",
+    },
+    {
+      name: "description",
+      content:
+        "Project editing screen, with form to update title, summary, tags and links.",
+    },
+  ];
+}
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const project = await getProjectById(params.id);
+
+  if (!project) {
+    throw new Response("Project not found", { status: 404 });
+  }
+
+  return { project };
+}
+
+export async function action({ params, request }: Route.ActionArgs) {
+  const authSession = await getAuthSession(request);
+
+  if (!authSession) {
+    const redirectTo = new URL(request.url).pathname;
+    throw redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`);
+  }
+
+  const formData = await request.formData();
+  const defaultValues = readProjectFormValues(formData);
+  const errors = validateProjectForm(defaultValues);
+
+  if (hasErrors(errors)) {
+    return data<ActionData>({ defaultValues, errors }, { status: 400 });
+  }
+
+  try {
+    const projectId = await updateProject(
+      params.id,
+      {
+        title: defaultValues.title,
+        summary: defaultValues.summary,
+        techTags: parseTechTags(defaultValues.techTags),
+        ...(defaultValues.demoUrl ? { demoUrl: defaultValues.demoUrl } : {}),
+        ...(defaultValues.repoUrl ? { repoUrl: defaultValues.repoUrl } : {}),
+        ...(defaultValues.imageUrl ? { imageUrl: defaultValues.imageUrl } : {}),
+      },
+      authSession.token,
+    );
+
+    return redirect(`/projects/${projectId}`);
+  } catch (error) {
+    return data<ActionData>(
+      {
+        defaultValues,
+        errors: {
+          form:
+            error instanceof ProjectRequestError
+              ? error.message
+              : "An unexpected error occurred while saving the project.",
+        },
+      },
+      {
+        status: error instanceof ProjectRequestError ? error.status : 500,
+      },
+    );
+  }
+}
+
+export default function EditProject() {
+  const { project } = useLoaderData<typeof loader>();
+  const actionData = useActionData<ActionData>();
+  const navigation = useNavigation();
+  const isSubmitting = navigation.state === "submitting";
+  const defaultValues =
+    actionData?.defaultValues ?? getProjectFormValues(project);
+
+  return (
+    <section className="space-y-8">
+      <header className="space-y-3">
+        <h1 className="text-4xl font-semibold tracking-tight text-stone-950">
+          Edit {project.title}
+        </h1>
+      </header>
+
+      <Form
+        action={`/projects/${project.id}/edit`}
+        className="grid gap-4 rounded-3xl border border-stone-200 bg-white p-8 shadow-sm"
+        method="post"
+      >
+        {actionData?.errors?.form && (
+          <div className="rounded-2xl border border-red-100 bg-red-50 p-4 text-sm text-red-600">
+            {actionData.errors.form}
+          </div>
+        )}
+
+        <Field
+          defaultValue={defaultValues.title}
+          error={actionData?.errors?.title}
+          label="Title"
+          name="title"
+          placeholder="My mini-project"
+        />
+        <Field
+          defaultValue={defaultValues.summary}
+          error={actionData?.errors?.summary}
+          label="Summary"
+          multiline
+          name="summary"
+          placeholder="Explain quickly the purpose of the project, the stack and the value."
+        />
+        <Field
+          defaultValue={defaultValues.techTags}
+          error={actionData?.errors?.techTags}
+          helperText="Separate tags with commas."
+          label="Technical Tags"
+          name="techTags"
+          placeholder="React, TypeScript, MySQL"
+        />
+        <Field
+          defaultValue={defaultValues.demoUrl}
+          error={actionData?.errors?.demoUrl}
+          label="Demo URL"
+          name="demoUrl"
+          placeholder="https://demo.example.com"
+        />
+        <Field
+          defaultValue={defaultValues.repoUrl}
+          error={actionData?.errors?.repoUrl}
+          label="GitHub URL"
+          name="repoUrl"
+          placeholder="https://github.com/me/project"
+        />
+        <Field
+          defaultValue={defaultValues.imageUrl}
+          error={actionData?.errors?.imageUrl}
+          label="Image URL"
+          name="imageUrl"
+          placeholder="https://images.example.com/cover.jpg"
+        />
+
+        <div className="flex flex-wrap gap-3 pt-2">
+          <button
+            className="rounded-full bg-stone-950 px-5 py-3 font-medium text-white"
+            disabled={isSubmitting}
+            type="submit"
+          >
+            {isSubmitting ? "Saving..." : "Save changes"}
+          </button>
+          <Link
+            className="rounded-full border border-stone-300 px-5 py-3 font-medium text-stone-700"
+            to={`/projects/${project.id}`}
+          >
+            Back to project details
+          </Link>
+        </div>
+      </Form>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  name,
+  placeholder,
+  defaultValue,
+  error,
+  helperText,
+  multiline = false,
+}: {
+  label: string;
+  name: keyof ProjectFormValues;
+  placeholder: string;
+  defaultValue?: string;
+  error?: string;
+  helperText?: string;
+  multiline?: boolean;
+}) {
+  return (
+    <label className="space-y-2">
+      <span className="text-sm font-medium text-stone-700">{label}</span>
+
+      {multiline ? (
+        <textarea
+          className="min-h-32 w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+          defaultValue={defaultValue}
+          name={name}
+          placeholder={placeholder}
+        />
+      ) : (
+        <input
+          className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+          defaultValue={defaultValue}
+          name={name}
+          placeholder={placeholder}
+          type="text"
+        />
+      )}
+
+      {helperText && !error && (
+        <p className="text-sm text-stone-500">{helperText}</p>
+      )}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </label>
+  );
+}
+
+function getProjectFormValues(project: ProjectWithAuthor): ProjectFormValues {
+  return {
+    title: project.title,
+    summary: project.summary,
+    techTags: project.techTags.join(", "),
+    demoUrl: project.demoUrl === "#" ? "" : project.demoUrl,
+    repoUrl: project.repoUrl === "#" ? "" : project.repoUrl,
+    imageUrl: project.imageUrl,
+  };
+}
+
+function readProjectFormValues(formData: FormData): ProjectFormValues {
+  return {
+    title: readFormValue(formData.get("title")),
+    summary: readFormValue(formData.get("summary")),
+    techTags: readFormValue(formData.get("techTags")),
+    demoUrl: readFormValue(formData.get("demoUrl")),
+    repoUrl: readFormValue(formData.get("repoUrl")),
+    imageUrl: readFormValue(formData.get("imageUrl")),
+  };
+}
+
+function validateProjectForm(values: ProjectFormValues): ProjectFormErrors {
+  const errors: ProjectFormErrors = {};
+
+  if (!values.title) {
+    errors.title = "Title is required.";
+  }
+
+  if (!values.summary) {
+    errors.summary = "Summary is required.";
+  }
+
+  if (parseTechTags(values.techTags).length === 0) {
+    errors.techTags = "Add at least one technical tag.";
+  }
+
+  if (values.demoUrl && !isValidUrl(values.demoUrl)) {
+    errors.demoUrl = "Enter a valid URL.";
+  }
+
+  if (values.repoUrl && !isValidUrl(values.repoUrl)) {
+    errors.repoUrl = "Enter a valid URL.";
+  }
+
+  if (values.imageUrl && !isValidUrl(values.imageUrl)) {
+    errors.imageUrl = "Enter a valid URL.";
+  }
+
+  return errors;
+}
+
+function hasErrors(errors: ProjectFormErrors) {
+  return Object.keys(errors).length > 0;
+}
+
+function parseTechTags(value: string) {
+  return value
+    .split(/,|\n/)
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+}
+
+function readFormValue(value: FormDataEntryValue | null) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isValidUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/app/routes/projects/newProject.tsx
+++ b/app/routes/projects/newProject.tsx
@@ -1,0 +1,286 @@
+import {
+  data,
+  Form,
+  Link,
+  redirect,
+  useActionData,
+  useNavigation,
+} from "react-router";
+
+import type { Route } from "./+types/newProject";
+import { getAuthSession } from "~/lib/auth.server";
+import { createProject, ProjectRequestError } from "~/lib/projects.server";
+
+type ProjectFormValues = {
+  title: string;
+  summary: string;
+  techTags: string;
+  demoUrl: string;
+  repoUrl: string;
+  imageUrl: string;
+};
+
+type ProjectFormErrors = Partial<
+  Record<keyof ProjectFormValues | "form", string>
+>;
+
+type ActionData = {
+  defaultValues: ProjectFormValues;
+  errors: ProjectFormErrors;
+};
+
+export function meta(_args: Route.MetaArgs) {
+  return [
+    { title: "New project | DemoDeck" },
+    {
+      name: "description",
+      content: "Publish a new project, with title, summary, tags and links.",
+    },
+  ];
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const authSession = await getAuthSession(request);
+
+  if (!authSession) {
+    throw redirect("/login?redirectTo=%2Fprojects%2Fnew");
+  }
+
+  const formData = await request.formData();
+  const defaultValues = readProjectFormValues(formData);
+  const errors = validateProjectForm(defaultValues);
+
+  if (hasErrors(errors)) {
+    return data<ActionData>({ defaultValues, errors }, { status: 400 });
+  }
+
+  try {
+    const project = await createProject(
+      {
+        title: defaultValues.title,
+        summary: defaultValues.summary,
+        techTags: parseTechTags(defaultValues.techTags),
+        ...(defaultValues.demoUrl ? { demoUrl: defaultValues.demoUrl } : {}),
+        ...(defaultValues.repoUrl ? { repoUrl: defaultValues.repoUrl } : {}),
+        ...(defaultValues.imageUrl ? { imageUrl: defaultValues.imageUrl } : {}),
+      },
+      authSession.token,
+    );
+
+    return redirect(`/projects/${project.id}`);
+  } catch (error) {
+    return data(
+      {
+        defaultValues,
+        errors: {
+          form:
+            error instanceof ProjectRequestError
+              ? error.message
+              : "An unexpected error occurred while publishing the project.",
+        },
+      },
+      {
+        status: error instanceof ProjectRequestError ? error.status : 500,
+      },
+    );
+  }
+}
+
+export default function NewProject() {
+  const actionData = useActionData<ActionData>();
+  const navigation = useNavigation();
+  const isSubmitting = navigation.state === "submitting";
+
+  return (
+    <section className="space-y-8">
+      <header className="space-y-3">
+        <h1 className="text-4xl font-semibold tracking-tight text-stone-950">
+          Publish a new project
+        </h1>
+      </header>
+
+      <Form
+        className="grid gap-4 rounded-3xl border border-stone-200 bg-white p-8 shadow-sm"
+        method="post"
+      >
+        {actionData?.errors?.form && (
+          <div className="rounded-2xl border border-red-100 bg-red-50 p-4 text-sm text-red-600">
+            {actionData.errors.form}
+          </div>
+        )}
+
+        <Field
+          defaultValue={actionData?.defaultValues?.title}
+          error={actionData?.errors?.title}
+          label="Title"
+          name="title"
+          placeholder="My mini-project"
+        />
+        <Field
+          defaultValue={actionData?.defaultValues?.summary}
+          error={actionData?.errors?.summary}
+          label="Summary"
+          multiline
+          name="summary"
+          placeholder="Explain quickly the purpose of the project, the stack and the value."
+        />
+        <Field
+          defaultValue={actionData?.defaultValues?.techTags}
+          error={actionData?.errors?.techTags}
+          helperText="Separate tags with commas."
+          label="Technical Tags"
+          name="techTags"
+          placeholder="React, TypeScript, MySQL"
+        />
+        <Field
+          defaultValue={actionData?.defaultValues?.demoUrl}
+          error={actionData?.errors?.demoUrl}
+          label="Demo URL"
+          name="demoUrl"
+          placeholder="https://demo.example.com"
+        />
+        <Field
+          defaultValue={actionData?.defaultValues?.repoUrl}
+          error={actionData?.errors?.repoUrl}
+          label="GitHub URL"
+          name="repoUrl"
+          placeholder="https://github.com/me/project"
+        />
+        <Field
+          defaultValue={actionData?.defaultValues?.imageUrl}
+          error={actionData?.errors?.imageUrl}
+          label="Image URL"
+          name="imageUrl"
+          placeholder="https://images.example.com/cover.jpg"
+        />
+
+        <div className="flex flex-wrap gap-3 pt-2">
+          <button
+            className="rounded-full bg-stone-950 px-5 py-3 font-medium text-white"
+            disabled={isSubmitting}
+            type="submit"
+          >
+            {isSubmitting ? "Publishing..." : "Publish project"}
+          </button>
+          <Link
+            className="rounded-full border border-stone-300 px-5 py-3 font-medium text-stone-700"
+            to="/"
+          >
+            Back to gallery
+          </Link>
+        </div>
+      </Form>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  name,
+  placeholder,
+  defaultValue,
+  error,
+  helperText,
+  multiline = false,
+}: {
+  label: string;
+  name: keyof ProjectFormValues;
+  placeholder: string;
+  defaultValue?: string;
+  error?: string;
+  helperText?: string;
+  multiline?: boolean;
+}) {
+  return (
+    <label className="space-y-2">
+      <span className="text-sm font-medium text-stone-700">{label}</span>
+
+      {multiline ? (
+        <textarea
+          className="min-h-32 w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+          defaultValue={defaultValue}
+          name={name}
+          placeholder={placeholder}
+        />
+      ) : (
+        <input
+          className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+          defaultValue={defaultValue}
+          name={name}
+          placeholder={placeholder}
+          type="text"
+        />
+      )}
+
+      {helperText && !error && (
+        <p className="text-sm text-stone-500">{helperText}</p>
+      )}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </label>
+  );
+}
+
+function readProjectFormValues(formData: FormData): ProjectFormValues {
+  return {
+    title: readFormValue(formData.get("title")),
+    summary: readFormValue(formData.get("summary")),
+    techTags: readFormValue(formData.get("techTags")),
+    demoUrl: readFormValue(formData.get("demoUrl")),
+    repoUrl: readFormValue(formData.get("repoUrl")),
+    imageUrl: readFormValue(formData.get("imageUrl")),
+  };
+}
+
+function validateProjectForm(values: ProjectFormValues): ProjectFormErrors {
+  const errors: ProjectFormErrors = {};
+
+  if (!values.title) {
+    errors.title = "Title is required.";
+  }
+
+  if (!values.summary) {
+    errors.summary = "Summary is required.";
+  }
+
+  if (parseTechTags(values.techTags).length === 0) {
+    errors.techTags = "Add at least one technical tag.";
+  }
+
+  if (values.demoUrl && !isValidUrl(values.demoUrl)) {
+    errors.demoUrl = "Enter a valid URL.";
+  }
+
+  if (values.repoUrl && !isValidUrl(values.repoUrl)) {
+    errors.repoUrl = "Enter a valid URL.";
+  }
+
+  if (values.imageUrl && !isValidUrl(values.imageUrl)) {
+    errors.imageUrl = "Enter a valid URL.";
+  }
+
+  return errors;
+}
+
+function hasErrors(errors: ProjectFormErrors) {
+  return Object.keys(errors).length > 0;
+}
+
+function parseTechTags(value: string) {
+  return value
+    .split(/,|\n/)
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+}
+
+function readFormValue(value: FormDataEntryValue | null) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isValidUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/app/routes/projects/newProject.tsx
+++ b/app/routes/projects/newProject.tsx
@@ -1,33 +1,22 @@
 import {
   data,
-  Form,
-  Link,
   redirect,
   useActionData,
   useNavigation,
 } from "react-router";
 
 import type { Route } from "./+types/newProject";
+import { ProjectEditorForm } from "~/components/ProjectEditorForm";
 import { getAuthSession } from "~/lib/auth.server";
 import { createProject, ProjectRequestError } from "~/lib/projects.server";
-
-type ProjectFormValues = {
-  title: string;
-  summary: string;
-  techTags: string;
-  demoUrl: string;
-  repoUrl: string;
-  imageUrl: string;
-};
-
-type ProjectFormErrors = Partial<
-  Record<keyof ProjectFormValues | "form", string>
->;
-
-type ActionData = {
-  defaultValues: ProjectFormValues;
-  errors: ProjectFormErrors;
-};
+import {
+  buildProjectInput,
+  getEmptyProjectFormValues,
+  hasProjectFormErrors,
+  readProjectFormValues,
+  type ProjectFormActionData,
+  validateProjectForm,
+} from "~/lib/project-form";
 
 export function meta(_args: Route.MetaArgs) {
   return [
@@ -50,26 +39,16 @@ export async function action({ request }: Route.ActionArgs) {
   const defaultValues = readProjectFormValues(formData);
   const errors = validateProjectForm(defaultValues);
 
-  if (hasErrors(errors)) {
-    return data<ActionData>({ defaultValues, errors }, { status: 400 });
+  if (hasProjectFormErrors(errors)) {
+    return data<ProjectFormActionData>({ defaultValues, errors }, { status: 400 });
   }
 
   try {
-    const project = await createProject(
-      {
-        title: defaultValues.title,
-        summary: defaultValues.summary,
-        techTags: parseTechTags(defaultValues.techTags),
-        ...(defaultValues.demoUrl ? { demoUrl: defaultValues.demoUrl } : {}),
-        ...(defaultValues.repoUrl ? { repoUrl: defaultValues.repoUrl } : {}),
-        ...(defaultValues.imageUrl ? { imageUrl: defaultValues.imageUrl } : {}),
-      },
-      authSession.token,
-    );
+    const project = await createProject(buildProjectInput(defaultValues), authSession.token);
 
     return redirect(`/projects/${project.id}`);
   } catch (error) {
-    return data(
+    return data<ProjectFormActionData>(
       {
         defaultValues,
         errors: {
@@ -87,9 +66,11 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export default function NewProject() {
-  const actionData = useActionData<ActionData>();
+  const actionData = useActionData<ProjectFormActionData>();
   const navigation = useNavigation();
   const isSubmitting = navigation.state === "submitting";
+  const defaultValues =
+    actionData?.defaultValues ?? getEmptyProjectFormValues();
 
   return (
     <section className="space-y-8">
@@ -99,188 +80,15 @@ export default function NewProject() {
         </h1>
       </header>
 
-      <Form
-        className="grid gap-4 rounded-3xl border border-stone-200 bg-white p-8 shadow-sm"
-        method="post"
-      >
-        {actionData?.errors?.form && (
-          <div className="rounded-2xl border border-red-100 bg-red-50 p-4 text-sm text-red-600">
-            {actionData.errors.form}
-          </div>
-        )}
-
-        <Field
-          defaultValue={actionData?.defaultValues?.title}
-          error={actionData?.errors?.title}
-          label="Title"
-          name="title"
-          placeholder="My mini-project"
-        />
-        <Field
-          defaultValue={actionData?.defaultValues?.summary}
-          error={actionData?.errors?.summary}
-          label="Summary"
-          multiline
-          name="summary"
-          placeholder="Explain quickly the purpose of the project, the stack and the value."
-        />
-        <Field
-          defaultValue={actionData?.defaultValues?.techTags}
-          error={actionData?.errors?.techTags}
-          helperText="Separate tags with commas."
-          label="Technical Tags"
-          name="techTags"
-          placeholder="React, TypeScript, MySQL"
-        />
-        <Field
-          defaultValue={actionData?.defaultValues?.demoUrl}
-          error={actionData?.errors?.demoUrl}
-          label="Demo URL"
-          name="demoUrl"
-          placeholder="https://demo.example.com"
-        />
-        <Field
-          defaultValue={actionData?.defaultValues?.repoUrl}
-          error={actionData?.errors?.repoUrl}
-          label="GitHub URL"
-          name="repoUrl"
-          placeholder="https://github.com/me/project"
-        />
-        <Field
-          defaultValue={actionData?.defaultValues?.imageUrl}
-          error={actionData?.errors?.imageUrl}
-          label="Image URL"
-          name="imageUrl"
-          placeholder="https://images.example.com/cover.jpg"
-        />
-
-        <div className="flex flex-wrap gap-3 pt-2">
-          <button
-            className="rounded-full bg-stone-950 px-5 py-3 font-medium text-white"
-            disabled={isSubmitting}
-            type="submit"
-          >
-            {isSubmitting ? "Publishing..." : "Publish project"}
-          </button>
-          <Link
-            className="rounded-full border border-stone-300 px-5 py-3 font-medium text-stone-700"
-            to="/"
-          >
-            Back to gallery
-          </Link>
-        </div>
-      </Form>
+      <ProjectEditorForm
+        cancelHref="/"
+        cancelLabel="Back to gallery"
+        defaultValues={defaultValues}
+        errors={actionData?.errors}
+        isSubmitting={isSubmitting}
+        submitLabel="Publish project"
+        submittingLabel="Publishing..."
+      />
     </section>
   );
-}
-
-function Field({
-  label,
-  name,
-  placeholder,
-  defaultValue,
-  error,
-  helperText,
-  multiline = false,
-}: {
-  label: string;
-  name: keyof ProjectFormValues;
-  placeholder: string;
-  defaultValue?: string;
-  error?: string;
-  helperText?: string;
-  multiline?: boolean;
-}) {
-  return (
-    <label className="space-y-2">
-      <span className="text-sm font-medium text-stone-700">{label}</span>
-
-      {multiline ? (
-        <textarea
-          className="min-h-32 w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
-          defaultValue={defaultValue}
-          name={name}
-          placeholder={placeholder}
-        />
-      ) : (
-        <input
-          className="w-full rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
-          defaultValue={defaultValue}
-          name={name}
-          placeholder={placeholder}
-          type="text"
-        />
-      )}
-
-      {helperText && !error && (
-        <p className="text-sm text-stone-500">{helperText}</p>
-      )}
-      {error && <p className="text-sm text-red-600">{error}</p>}
-    </label>
-  );
-}
-
-function readProjectFormValues(formData: FormData): ProjectFormValues {
-  return {
-    title: readFormValue(formData.get("title")),
-    summary: readFormValue(formData.get("summary")),
-    techTags: readFormValue(formData.get("techTags")),
-    demoUrl: readFormValue(formData.get("demoUrl")),
-    repoUrl: readFormValue(formData.get("repoUrl")),
-    imageUrl: readFormValue(formData.get("imageUrl")),
-  };
-}
-
-function validateProjectForm(values: ProjectFormValues): ProjectFormErrors {
-  const errors: ProjectFormErrors = {};
-
-  if (!values.title) {
-    errors.title = "Title is required.";
-  }
-
-  if (!values.summary) {
-    errors.summary = "Summary is required.";
-  }
-
-  if (parseTechTags(values.techTags).length === 0) {
-    errors.techTags = "Add at least one technical tag.";
-  }
-
-  if (values.demoUrl && !isValidUrl(values.demoUrl)) {
-    errors.demoUrl = "Enter a valid URL.";
-  }
-
-  if (values.repoUrl && !isValidUrl(values.repoUrl)) {
-    errors.repoUrl = "Enter a valid URL.";
-  }
-
-  if (values.imageUrl && !isValidUrl(values.imageUrl)) {
-    errors.imageUrl = "Enter a valid URL.";
-  }
-
-  return errors;
-}
-
-function hasErrors(errors: ProjectFormErrors) {
-  return Object.keys(errors).length > 0;
-}
-
-function parseTechTags(value: string) {
-  return value
-    .split(/,|\n/)
-    .map((tag) => tag.trim())
-    .filter((tag) => tag.length > 0);
-}
-
-function readFormValue(value: FormDataEntryValue | null) {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function isValidUrl(value: string) {
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
-  } catch {
-    return false;
-  }
 }

--- a/app/routes/projects/projectDetail.tsx
+++ b/app/routes/projects/projectDetail.tsx
@@ -1,6 +1,5 @@
 import {
   data,
-  Form,
   Link,
   redirect,
   useActionData,
@@ -10,6 +9,8 @@ import {
 } from "react-router";
 
 import type { Route } from "./+types/projectDetail";
+import { InfoBlock } from "~/components/InfoBlock";
+import { ProjectOwnerActions } from "~/components/ProjectOwnerActions";
 import { getAuthSession } from "~/lib/auth.server";
 import {
   deleteProject,
@@ -156,36 +157,10 @@ export default function ProjectDetail() {
                 Open GitHub
               </a>
               {isOwner && (
-                <>
-                  <Link
-                    className="rounded-full border border-stone-300 px-4 py-2 text-sm font-medium text-stone-700"
-                    to={`/projects/${project.id}/edit`}
-                  >
-                    Edit project
-                  </Link>
-                  <Form
-                    action={`/projects/${project.id}`}
-                    method="post"
-                    onSubmit={(event) => {
-                      const isConfirmed = window.confirm(
-                        "Delete this project permanently?",
-                      );
-
-                      if (!isConfirmed) {
-                        event.preventDefault();
-                      }
-                    }}
-                  >
-                    <input name="_intent" type="hidden" value="delete" />
-                    <button
-                      className="rounded-full border border-red-200 px-4 py-2 text-sm font-medium text-red-700 transition hover:bg-red-50 disabled:opacity-70"
-                      disabled={isDeleting}
-                      type="submit"
-                    >
-                      {isDeleting ? "Deleting..." : "Delete project"}
-                    </button>
-                  </Form>
-                </>
+                <ProjectOwnerActions
+                  isDeleting={isDeleting}
+                  projectId={project.id}
+                />
               )}
             </div>
             {actionData?.errors?.form && (
@@ -214,16 +189,5 @@ export default function ProjectDetail() {
         </aside>
       </div>
     </section>
-  );
-}
-
-function InfoBlock({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-2xl bg-stone-100 p-4">
-      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-stone-500">
-        {label}
-      </p>
-      <p className="mt-2 break-all text-sm text-stone-700">{value}</p>
-    </div>
   );
 }

--- a/app/routes/projects/projectDetail.tsx
+++ b/app/routes/projects/projectDetail.tsx
@@ -1,7 +1,27 @@
-import { Link, useLoaderData } from "react-router";
+import {
+  data,
+  Form,
+  Link,
+  redirect,
+  useActionData,
+  useLoaderData,
+  useNavigation,
+  useRouteLoaderData,
+} from "react-router";
 
 import type { Route } from "./+types/projectDetail";
-import { getProjectById } from "~/lib/projects.server";
+import { getAuthSession } from "~/lib/auth.server";
+import {
+  deleteProject,
+  getProjectById,
+  ProjectRequestError,
+} from "~/lib/projects.server";
+
+type ActionData = {
+  errors: {
+    form: string;
+  };
+};
 
 export function meta({ data }: Route.MetaArgs) {
   return [
@@ -28,8 +48,52 @@ export async function loader({ params }: Route.LoaderArgs) {
   return { project };
 }
 
+export async function action({ params, request }: Route.ActionArgs) {
+  const formData = await request.formData();
+
+  if (formData.get("_intent") !== "delete") {
+    return data<ActionData>(
+      { errors: { form: "Unsupported project action." } },
+      { status: 405 },
+    );
+  }
+
+  const authSession = await getAuthSession(request);
+
+  if (!authSession) {
+    const redirectTo = new URL(request.url).pathname;
+    throw redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`);
+  }
+
+  try {
+    await deleteProject(params.id, authSession.token);
+    return redirect("/");
+  } catch (error) {
+    return data<ActionData>(
+      {
+        errors: {
+          form:
+            error instanceof ProjectRequestError
+              ? error.message
+              : "An unexpected error occurred while deleting the project.",
+        },
+      },
+      {
+        status: error instanceof ProjectRequestError ? error.status : 500,
+      },
+    );
+  }
+}
+
 export default function ProjectDetail() {
   const { project } = useLoaderData<typeof loader>();
+  const actionData = useActionData<ActionData>();
+  const navigation = useNavigation();
+  const rootData = useRouteLoaderData<typeof import("~/root").loader>("root");
+  const isDeleting =
+    navigation.state === "submitting" &&
+    navigation.formData?.get("_intent") === "delete";
+  const isOwner = rootData?.user?.id === project.author.id;
 
   return (
     <section className="space-y-8">
@@ -91,13 +155,44 @@ export default function ProjectDetail() {
               >
                 Open GitHub
               </a>
-              <Link
-                className="rounded-full border border-stone-300 px-4 py-2 text-sm font-medium text-stone-700"
-                to={`/projects/${project.id}/edit`}
-              >
-                Edit project
-              </Link>
+              {isOwner && (
+                <>
+                  <Link
+                    className="rounded-full border border-stone-300 px-4 py-2 text-sm font-medium text-stone-700"
+                    to={`/projects/${project.id}/edit`}
+                  >
+                    Edit project
+                  </Link>
+                  <Form
+                    action={`/projects/${project.id}`}
+                    method="post"
+                    onSubmit={(event) => {
+                      const isConfirmed = window.confirm(
+                        "Delete this project permanently?",
+                      );
+
+                      if (!isConfirmed) {
+                        event.preventDefault();
+                      }
+                    }}
+                  >
+                    <input name="_intent" type="hidden" value="delete" />
+                    <button
+                      className="rounded-full border border-red-200 px-4 py-2 text-sm font-medium text-red-700 transition hover:bg-red-50 disabled:opacity-70"
+                      disabled={isDeleting}
+                      type="submit"
+                    >
+                      {isDeleting ? "Deleting..." : "Delete project"}
+                    </button>
+                  </Form>
+                </>
+              )}
             </div>
+            {actionData?.errors?.form && (
+              <div className="rounded-2xl border border-red-100 bg-red-50 p-4 text-sm text-red-600">
+                {actionData.errors.form}
+              </div>
+            )}
           </div>
         </article>
 


### PR DESCRIPTION
## Summary

This pull request completes the frontend integration for the `projects` feature and refactors the related code to better follow React’s separation of concerns.

The `new project`, `edit project`, and `delete project` flows are now connected to the real backend API instead of local placeholders or fake data. Users can now create a project with an authenticated `POST /api/projects`, update an existing one with `PUT /api/projects/:id`, and delete their own project with `DELETE /api/projects/:id`. A confirmation popup was also added before deletion to prevent accidental removals.

In addition to the API integration, the project-related frontend code was cleaned up and modularized. Shared form logic such as field parsing, validation, and payload building was extracted into a dedicated helper module, and duplicated form UI between `newProject` and `editProject` was moved into a reusable component. On the detail page, repeated UI blocks and owner-only actions were also extracted into separate components to keep the route files focused on routing, loading, and action handling.

## Main Changes

- Connected `newProject.tsx` to the backend `POST /api/projects`
- Connected `editProject.tsx` to the backend `PUT /api/projects/:id`
- Added project deletion from the detail page with backend `DELETE /api/projects/:id`
- Added a confirmation popup before deleting a project
- Fixed `techTags` parsing/display when backend JSON values are returned as strings
- Extracted shared project form logic into `app/lib/project-form.ts`
- Created reusable UI components for:
  - project create/edit form
  - owner actions on project detail
  - info blocks on the detail page

## Refactoring

The goal of the refactor was to make the project feature easier to maintain and more aligned with React best practices:

- Route files now focus on loaders, actions, redirects, and page composition
- Reusable UI was moved into dedicated components
- Shared validation and transformation logic was centralized in one place
- Duplicate code between create/edit flows was removed

## Notes

- `npm run typecheck` was run after the changes
- Remaining type errors are pre-existing and related to missing generated `+types` files in the `authors` and `notFound` routes
- No new type errors were introduced by this PR
