### PR TITLE
feat: added toast for event (success, error, etc.)

### DIFF
--- a/app/components/ToastProvider.tsx
+++ b/app/components/ToastProvider.tsx
@@ -1,0 +1,140 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { createToast, type Toast, type ToastInput } from "~/lib/toast";
+
+const TOAST_DURATION_MS = 4500;
+
+type ToastContextValue = {
+  pushToast: (toast: ToastInput) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({
+  children,
+  initialToast,
+}: {
+  children: React.ReactNode;
+  initialToast?: Toast | null;
+}) {
+  const [toasts, setToasts] = useState<Toast[]>(() =>
+    initialToast ? [initialToast] : [],
+  );
+  const lastInitialToastId = useRef<string | null>(initialToast?.id ?? null);
+
+  useEffect(() => {
+    if (!initialToast || lastInitialToastId.current === initialToast.id) {
+      return;
+    }
+
+    lastInitialToastId.current = initialToast.id;
+    setToasts((currentToasts) => [...currentToasts, initialToast]);
+  }, [initialToast]);
+
+  function pushToast(toast: ToastInput) {
+    setToasts((currentToasts) => [...currentToasts, createToast(toast)]);
+  }
+
+  function dismissToast(toastId: string) {
+    setToasts((currentToasts) =>
+      currentToasts.filter((toast) => toast.id !== toastId),
+    );
+  }
+
+  return (
+    <ToastContext.Provider value={{ pushToast }}>
+      {children}
+      <ToastViewport onDismiss={dismissToast} toasts={toasts} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider.");
+  }
+
+  return context;
+}
+
+function ToastViewport({
+  onDismiss,
+  toasts,
+}: {
+  onDismiss: (toastId: string) => void;
+  toasts: Toast[];
+}) {
+  if (toasts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className="pointer-events-none fixed inset-x-0 top-4 z-50 flex justify-center px-4 sm:justify-end sm:px-6"
+      role="status"
+    >
+      <div className="flex w-full max-w-sm flex-col gap-3">
+        {toasts.map((toast) => (
+          <ToastCard key={toast.id} onDismiss={onDismiss} toast={toast} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ToastCard({
+  onDismiss,
+  toast,
+}: {
+  onDismiss: (toastId: string) => void;
+  toast: Toast;
+}) {
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      onDismiss(toast.id);
+    }, TOAST_DURATION_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [onDismiss, toast.id]);
+
+  const accentClasses =
+    toast.type === "success"
+      ? "border-emerald-200 bg-emerald-50 text-emerald-950"
+      : "border-red-200 bg-red-50 text-red-950";
+  const label = toast.type === "success" ? "Success" : "Error";
+
+  return (
+    <section
+      className={`pointer-events-auto rounded-3xl border p-4 shadow-lg shadow-stone-950/8 backdrop-blur ${accentClasses}`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em]">
+            {label}
+          </p>
+          <p className="mt-1 text-sm leading-6">{toast.message}</p>
+        </div>
+        <button
+          aria-label="Dismiss notification"
+          className="rounded-full px-2 py-1 text-xs font-medium text-current/70 transition hover:bg-white/60 hover:text-current"
+          onClick={() => onDismiss(toast.id)}
+          type="button"
+        >
+          Close
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/app/lib/auth.server.ts
+++ b/app/lib/auth.server.ts
@@ -7,7 +7,9 @@ import {
   readNumber,
   readString,
 } from "./backend.server";
+import type { ToastInput } from "./toast";
 import { commitSession, destroySession, getSession } from "./session.server";
+import { flashToast } from "./session.server";
 
 const AUTH_SESSION_KEY = "authSession";
 
@@ -143,14 +145,28 @@ export async function isAuthenticated(request: Request): Promise<boolean> {
 export async function createAuthCookie(
   request: Request,
   authSession: AuthSession,
+  toast?: ToastInput,
 ): Promise<string> {
   const session = await getSession(request.headers.get("Cookie"));
   session.set(AUTH_SESSION_KEY, authSession);
+  if (toast) {
+    flashToast(session, toast);
+  }
   return commitSession(session);
 }
 
-export async function destroyAuthCookie(request: Request): Promise<string> {
+export async function destroyAuthCookie(
+  request: Request,
+  toast?: ToastInput,
+): Promise<string> {
   const session = await getSession(request.headers.get("Cookie"));
+
+  if (toast) {
+    session.unset(AUTH_SESSION_KEY);
+    flashToast(session, toast);
+    return commitSession(session);
+  }
+
   return destroySession(session);
 }
 

--- a/app/lib/session.server.ts
+++ b/app/lib/session.server.ts
@@ -1,5 +1,6 @@
 import { createCookieSessionStorage } from "react-router";
 import { ENV } from "~/config/env.server";
+import { createToast, isToast, type Toast, type ToastInput } from "~/lib/toast";
 
 export const sessionStorage = createCookieSessionStorage({
   cookie: {
@@ -13,3 +14,39 @@ export const sessionStorage = createCookieSessionStorage({
 });
 
 export const { getSession, commitSession, destroySession } = sessionStorage;
+
+const TOAST_SESSION_KEY = "toast";
+
+export async function createToastCookie(
+  request: Request,
+  toast: ToastInput,
+): Promise<string> {
+  const session = await getSession(request.headers.get("Cookie"));
+  flashToast(session, toast);
+  return commitSession(session);
+}
+
+export async function getToast(
+  request: Request,
+): Promise<{ headers: HeadersInit | null; toast: Toast | null }> {
+  const session = await getSession(request.headers.get("Cookie"));
+  const flashedToast = session.get(TOAST_SESSION_KEY);
+
+  if (!isToast(flashedToast)) {
+    return { headers: null, toast: null };
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": await commitSession(session),
+    },
+    toast: flashedToast,
+  };
+}
+
+export function flashToast(
+  session: Awaited<ReturnType<typeof getSession>>,
+  toast: ToastInput | Toast,
+) {
+  session.flash(TOAST_SESSION_KEY, isToast(toast) ? toast : createToast(toast));
+}

--- a/app/lib/toast.ts
+++ b/app/lib/toast.ts
@@ -1,0 +1,40 @@
+export type ToastType = "success" | "error";
+
+export type ToastInput = {
+  message: string;
+  type: ToastType;
+};
+
+export type Toast = ToastInput & {
+  id: string;
+};
+
+export function createToast({ message, type }: ToastInput): Toast {
+  return {
+    id: createToastId(),
+    message,
+    type,
+  };
+}
+
+export function isToast(value: unknown): value is Toast {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const toast = value as Partial<Toast>;
+
+  return (
+    typeof toast.id === "string" &&
+    typeof toast.message === "string" &&
+    (toast.type === "success" || toast.type === "error")
+  );
+}
+
+function createToastId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `toast-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import {
+  data,
   isRouteErrorResponse,
   Links,
   Meta,
@@ -21,6 +22,8 @@ import {
 import { logout, setCredentials } from "~/state/auth/authSlice";
 import { store } from "./config/store";
 import { Navbar } from "./components/Navbar";
+import { ToastProvider } from "./components/ToastProvider";
+import { getToast } from "./lib/session.server";
 
 export const links: Route.LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -36,12 +39,21 @@ export const links: Route.LinksFunction = () => [
 ];
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const authSession = await getAuthSession(request);
+  const [authSession, toastState] = await Promise.all([
+    getAuthSession(request),
+    getToast(request),
+  ]);
 
-  return {
-    isAuthenticated: authSession !== null,
-    user: authSession?.user ?? null,
-  };
+  return data(
+    {
+      isAuthenticated: authSession !== null,
+      toast: toastState.toast,
+      user: authSession?.user ?? null,
+    },
+    {
+      headers: toastState.headers ?? undefined,
+    },
+  );
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -49,7 +61,12 @@ export async function action({ request }: Route.ActionArgs) {
 
   if (formData.get("_intent") === "logout") {
     return redirect("/", {
-      headers: { "Set-Cookie": await destroyAuthCookie(request) },
+      headers: {
+        "Set-Cookie": await destroyAuthCookie(request, {
+          message: "Signed out successfully.",
+          type: "success",
+        }),
+      },
     });
   }
 
@@ -75,7 +92,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
-  const { isAuthenticated, user } = useLoaderData<typeof loader>();
+  const { isAuthenticated, toast, user } = useLoaderData<typeof loader>();
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -94,13 +111,15 @@ export default function App() {
   }, [dispatch, isAuthenticated, user]);
 
   return (
-    <div className="min-h-screen bg-stone-100 text-stone-950">
-      <Navbar isAuthenticated={isAuthenticated} />
+    <ToastProvider initialToast={toast}>
+      <div className="min-h-screen bg-stone-100 text-stone-950">
+        <Navbar isAuthenticated={isAuthenticated} />
 
-      <main className="mx-auto max-w-6xl px-6 py-10">
-        <Outlet />
-      </main>
-    </div>
+        <main className="mx-auto max-w-6xl px-6 py-10">
+          <Outlet />
+        </main>
+      </div>
+    </ToastProvider>
   );
 }
 

--- a/app/routes/auth/login.tsx
+++ b/app/routes/auth/login.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from "react";
 import { data, redirect, useActionData } from "react-router";
 
 import type { Route } from "./+types/login";
 import { AuthScreen } from "~/components/AuthScreen";
+import { useToast } from "~/components/ToastProvider";
 import {
   authenticateUser,
   createAuthCookie,
@@ -57,7 +59,10 @@ export async function action({ request }: Route.ActionArgs) {
       );
     }
 
-    const cookieHeader = await createAuthCookie(request, session);
+    const cookieHeader = await createAuthCookie(request, session, {
+      message: "Welcome back.",
+      type: "success",
+    });
 
     return redirect(redirectTo, {
       headers: { "Set-Cookie": cookieHeader },
@@ -80,6 +85,18 @@ export async function action({ request }: Route.ActionArgs) {
 
 export default function Login() {
   const actionData = useActionData<typeof action>();
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (!actionData?.errors?.form) {
+      return;
+    }
+
+    pushToast({
+      message: actionData.errors.form,
+      type: "error",
+    });
+  }, [actionData, pushToast]);
 
   return (
     <AuthScreen

--- a/app/routes/auth/register.tsx
+++ b/app/routes/auth/register.tsx
@@ -1,8 +1,10 @@
+import { useEffect } from "react";
 import { data, redirect, useActionData } from "react-router";
 import type { Route } from "./+types/register";
 
 import { validateRegistrationData } from "~/helpers/auth/validation";
 import { AuthScreen } from "~/components/AuthScreen";
+import { useToast } from "~/components/ToastProvider";
 import {
   authenticateUser,
   createAuthCookie,
@@ -60,7 +62,10 @@ export async function action({ request }: Route.ActionArgs) {
       );
     }
 
-    const cookieHeader = await createAuthCookie(request, session);
+    const cookieHeader = await createAuthCookie(request, session, {
+      message: "Account created successfully.",
+      type: "success",
+    });
 
     return redirect(redirectTo, {
       headers: { "Set-Cookie": cookieHeader },
@@ -83,6 +88,18 @@ export async function action({ request }: Route.ActionArgs) {
 
 export default function Register() {
   const actionData = useActionData<typeof action>();
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (!actionData?.errors?.form) {
+      return;
+    }
+
+    pushToast({
+      message: actionData.errors.form,
+      type: "error",
+    });
+  }, [actionData, pushToast]);
 
   return (
     <AuthScreen

--- a/app/routes/projects/editProject.tsx
+++ b/app/routes/projects/editProject.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import {
   data,
   redirect,
@@ -8,12 +9,14 @@ import {
 
 import type { Route } from "./+types/editProject";
 import { ProjectEditorForm } from "~/components/ProjectEditorForm";
+import { useToast } from "~/components/ToastProvider";
 import { getAuthSession } from "~/lib/auth.server";
 import {
   getProjectById,
   ProjectRequestError,
   updateProject,
 } from "~/lib/projects.server";
+import { createToastCookie } from "~/lib/session.server";
 import {
   buildProjectInput,
   getProjectFormValues,
@@ -53,7 +56,14 @@ export async function action({ params, request }: Route.ActionArgs) {
 
   if (!authSession) {
     const redirectTo = new URL(request.url).pathname;
-    throw redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`);
+    throw redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`, {
+      headers: {
+        "Set-Cookie": await createToastCookie(request, {
+          message: "Please log in to edit this project.",
+          type: "error",
+        }),
+      },
+    });
   }
 
   const formData = await request.formData();
@@ -67,7 +77,14 @@ export async function action({ params, request }: Route.ActionArgs) {
   try {
     const projectId = await updateProject(params.id, buildProjectInput(defaultValues), authSession.token);
 
-    return redirect(`/projects/${projectId}`);
+    return redirect(`/projects/${projectId}`, {
+      headers: {
+        "Set-Cookie": await createToastCookie(request, {
+          message: "Project updated successfully.",
+          type: "success",
+        }),
+      },
+    });
   } catch (error) {
     return data<ProjectFormActionData>(
       {
@@ -90,9 +107,21 @@ export default function EditProject() {
   const { project } = useLoaderData<typeof loader>();
   const actionData = useActionData<ProjectFormActionData>();
   const navigation = useNavigation();
+  const { pushToast } = useToast();
   const isSubmitting = navigation.state === "submitting";
   const defaultValues =
     actionData?.defaultValues ?? getProjectFormValues(project);
+
+  useEffect(() => {
+    if (!actionData?.errors?.form) {
+      return;
+    }
+
+    pushToast({
+      message: actionData.errors.form,
+      type: "error",
+    });
+  }, [actionData, pushToast]);
 
   return (
     <section className="space-y-8">

--- a/app/routes/projects/newProject.tsx
+++ b/app/routes/projects/newProject.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import {
   data,
   redirect,
@@ -7,8 +8,10 @@ import {
 
 import type { Route } from "./+types/newProject";
 import { ProjectEditorForm } from "~/components/ProjectEditorForm";
+import { useToast } from "~/components/ToastProvider";
 import { getAuthSession } from "~/lib/auth.server";
 import { createProject, ProjectRequestError } from "~/lib/projects.server";
+import { createToastCookie } from "~/lib/session.server";
 import {
   buildProjectInput,
   getEmptyProjectFormValues,
@@ -32,7 +35,14 @@ export async function action({ request }: Route.ActionArgs) {
   const authSession = await getAuthSession(request);
 
   if (!authSession) {
-    throw redirect("/login?redirectTo=%2Fprojects%2Fnew");
+    throw redirect("/login?redirectTo=%2Fprojects%2Fnew", {
+      headers: {
+        "Set-Cookie": await createToastCookie(request, {
+          message: "Please log in to publish a project.",
+          type: "error",
+        }),
+      },
+    });
   }
 
   const formData = await request.formData();
@@ -46,7 +56,14 @@ export async function action({ request }: Route.ActionArgs) {
   try {
     const project = await createProject(buildProjectInput(defaultValues), authSession.token);
 
-    return redirect(`/projects/${project.id}`);
+    return redirect(`/projects/${project.id}`, {
+      headers: {
+        "Set-Cookie": await createToastCookie(request, {
+          message: "Project published successfully.",
+          type: "success",
+        }),
+      },
+    });
   } catch (error) {
     return data<ProjectFormActionData>(
       {
@@ -68,9 +85,21 @@ export async function action({ request }: Route.ActionArgs) {
 export default function NewProject() {
   const actionData = useActionData<ProjectFormActionData>();
   const navigation = useNavigation();
+  const { pushToast } = useToast();
   const isSubmitting = navigation.state === "submitting";
   const defaultValues =
     actionData?.defaultValues ?? getEmptyProjectFormValues();
+
+  useEffect(() => {
+    if (!actionData?.errors?.form) {
+      return;
+    }
+
+    pushToast({
+      message: actionData.errors.form,
+      type: "error",
+    });
+  }, [actionData, pushToast]);
 
   return (
     <section className="space-y-8">

--- a/app/routes/projects/projectDetail.tsx
+++ b/app/routes/projects/projectDetail.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import {
   data,
   Form,
@@ -12,6 +13,7 @@ import {
 import type { Route } from "./+types/projectDetail";
 import { InfoBlock } from "~/components/InfoBlock";
 import { ProjectOwnerActions } from "~/components/ProjectOwnerActions";
+import { useToast } from "~/components/ToastProvider";
 import { getAuthSession } from "~/lib/auth.server";
 import {
   createProjectComment,
@@ -20,6 +22,7 @@ import {
   likeProject,
   ProjectRequestError,
 } from "~/lib/projects.server";
+import { createToastCookie } from "~/lib/session.server";
 
 type CommentFormValues = {
   authorName: string;
@@ -140,17 +143,38 @@ export async function action({ params, request }: Route.ActionArgs) {
   const authSession = await getAuthSession(request);
 
   if (!authSession) {
-    throw redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`);
+    throw redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`, {
+      headers: {
+        "Set-Cookie": await createToastCookie(request, {
+          message: "Please log in to continue.",
+          type: "error",
+        }),
+      },
+    });
   }
 
   try {
     if (intent === "delete") {
       await deleteProject(params.id, authSession.token);
-      return redirect("/");
+      return redirect("/", {
+        headers: {
+          "Set-Cookie": await createToastCookie(request, {
+            message: "Project deleted successfully.",
+            type: "success",
+          }),
+        },
+      });
     }
 
     await likeProject(params.id, authSession.token);
-    return redirect(redirectTo);
+    return redirect(redirectTo, {
+      headers: {
+        "Set-Cookie": await createToastCookie(request, {
+          message: "Thanks for liking this project.",
+          type: "success",
+        }),
+      },
+    });
   } catch (error) {
     return data<ActionData>(
       {
@@ -174,6 +198,7 @@ export default function ProjectDetail() {
   const actionData = useActionData<ActionData>();
   const navigation = useNavigation();
   const rootData = useRouteLoaderData<typeof import("~/root").loader>("root");
+  const { pushToast } = useToast();
   const isAuthenticated = rootData?.isAuthenticated ?? false;
   const commentValues = actionData?.commentValues ?? getEmptyCommentValues();
   const commentFormKey = `${commentValues.authorName}:${commentValues.text}`;
@@ -189,6 +214,28 @@ export default function ProjectDetail() {
     navigation.state === "submitting" &&
     navigation.formData?.get("_intent") === "comment";
   const isOwner = rootData?.user?.id === project.author.id;
+
+  useEffect(() => {
+    if (!actionData?.errors?.form) {
+      return;
+    }
+
+    pushToast({
+      message: actionData.errors.form,
+      type: "error",
+    });
+  }, [actionData, pushToast]);
+
+  useEffect(() => {
+    if (!actionData?.createdComment) {
+      return;
+    }
+
+    pushToast({
+      message: "Comment published successfully.",
+      type: "success",
+    });
+  }, [actionData?.createdComment, pushToast]);
 
   return (
     <section className="space-y-8">


### PR DESCRIPTION
## Summary

This branch adds a global toast/alert system to improve user feedback across the app.

Users now see clear success and error messages for important actions such as:
- successful login / registration
- failed login or backend errors
- publishing a project
- editing or deleting a project
- liking a project
- posting a comment
- logging out

## What changed

- Added a shared toast model and a global `ToastProvider` rendered from the root layout.
- Added session-based flash toasts so messages survive redirects.
- Wired toast messages into the main auth and project actions.
- Kept existing inline form validation/errors, while also surfacing important feedback as toasts.

## Technical details

- New shared toast types/helpers were added to manage toast payloads.
- Session helpers now support flashing one-time toast messages.
- The root loader reads flashed toasts and displays them globally.
- Route actions trigger success/error toasts depending on the result of the operation.

## Why

Before this change, feedback was mostly limited to inline form errors and some actions had no clear confirmation at all. This branch makes the UX more consistent and helps users understand whether an action succeeded or failed immediately.